### PR TITLE
Support additional cidrs for k8s clusters

### DIFF
--- a/deploy/helm/scf/assets/operations/instance_groups/singleton-blobstore.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/singleton-blobstore.yaml
@@ -6,6 +6,9 @@
   value: 102400 # 100GB
 
 - type: replace
+  path: /instance_groups/name=singleton-blobstore/jobs/name=blobstore/properties/blobstore/internal_access_rules?
+  value: [ "allow 10.0.0.0/8;","allow 172.16.0.0/12;", "allow 192.168.0.0/16;" , "allow 100.64.0.0/10;"]
+- type: replace
   path: /instance_groups/name=singleton-blobstore/jobs/name=blobstore/properties/quarks?
   value:
     ports:


### PR DESCRIPTION
## Description

Currently cf on k8s doesn't support clusters created by [kops](https://github.com/kubernetes/kops) or [gardener](https://gardener.cloud/), because they uses different cidrs (100.64.0.0/10). See also [Dedicated space for carrier-grade NAT deployment](https://en.wikipedia.org/wiki/Private_network#Dedicated_space_for_carrier-grade_NAT_deployment)

## Test plan

Manual test
