### PR TITLE
Fixed blobstore and eirini addresses

### DIFF
--- a/deploy/helm/scf/assets/operations/instance_groups/eirini.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/eirini.yaml
@@ -104,7 +104,7 @@
           nats_ip: nats.service.cf.internal
           certs_secret_name: eirini-staging-secret
           cc_internal_api: https://cloud-controller-ng.service.cf.internal:9023
-          eirini_address: https://eirini.service.cf.internal:8484
+          eirini_address: https://{{ .Values.deployment_name }}-eirini.{{ .Release.Namespace }}:8484
           downloader_image: "eirini/recipe-downloader:0.3.0"
           uploader_image: "eirini/recipe-uploader:0.3.0"
           executor_image: "eirini/recipe-executor:0.3.0"
@@ -141,6 +141,32 @@
       alias: default
       os: opensuse-42.3
       version: 36.g03b4653-30.80-7.0.0_360.g0ec8d681
+
+# Set the correct addresses to be reached by the Eirini apps namespace.
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/buildpacks?/webdav_config/private_endpoint
+  value: &blobstore_url "https://{{ .Values.deployment_name }}-singleton-blobstore.{{ .Release.Namespace }}:4443"
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/droplets?/webdav_config/private_endpoint
+  value: *blobstore_url
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/packages?/webdav_config/private_endpoint
+  value: *blobstore_url
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/resource_pool?/webdav_config/private_endpoint
+  value: *blobstore_url
+- type: replace
+  path: /variables/name=blobstore_tls/options/alternative_names?/-
+  value: "{{ .Values.deployment_name }}-singleton-blobstore"
+- type: replace
+  path: /variables/name=blobstore_tls/options/alternative_names?/-
+  value: "{{ .Values.deployment_name }}-singleton-blobstore.{{ .Release.Namespace }}"
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cc_uploader/properties/internal_hostname?
+  value: "{{ .Values.deployment_name }}-api.{{ .Release.Namespace }}"
+- type: replace
+  path: /variables/name=cc_bridge_cc_uploader_server/options/alternative_names?/-
+  value: "{{ .Values.deployment_name }}-api.{{ .Release.Namespace }}"
 
 # Enable OPI in CC
 # cloud_controller_ng
@@ -211,8 +237,10 @@
     type: certificate
     options:
       ca: service_cf_internal_ca
-      common_name: {{ .Values.deployment_name }}-eirini
+      common_name: "{{ .Values.deployment_name }}-eirini"
       alternative_names:
+      - "{{ .Values.deployment_name }}-eirini"
+      - "{{ .Values.deployment_name }}-eirini.{{ .Release.Namespace }}"
       - eirini.service.cf.internal
       extended_key_usage:
       - server_auth


### PR DESCRIPTION
## Description

Resolves https://github.com/SUSE/kubecf/issues/61.

Depends on https://github.com/cloudfoundry-incubator/cf-operator/pull/661.

## Test plan

`cf push` and assert that the pods on the eirini namespace during the staging step is able to communicate with the blobstore and eirini opi.