### PR TITLE
Introduce registry credentials secret template

### DIFF
--- a/deploy/helm/scf/templates/registry-credentials.yaml
+++ b/deploy/helm/scf/templates/registry-credentials.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.releases.credentials -}}
+---
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/dockerconfigjson
+metadata:
+  name: registry-credentials
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "scf.fullname" . }}
+    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "scf.chart" . }}
+data:
+  .dockerconfigjson: {{ printf "{%q:{%q:{%q:%q,%q:%q,%q:%q}}}" "auths" .Values.releases.credentials.hostname "username" .Values.releases.credentials.username "password" .Values.releases.credentials.password "auth" (printf "%s:%s" .Values.releases.credentials.username .Values.releases.credentials.password | b64enc) | b64enc }}
+{{- end }}


### PR DESCRIPTION
## Description

Some Docker images may be located in a private Docker registry and therefore require an `imagePullSecret` in order to be pulled.

Analog to SCF v2, introduce template to create a secret containing the configured registry credentials for a hostname.

The location of the registry credential details is based on the [BOSH to Kube](https://github.com/cloudfoundry-incubator/cf-operator/blob/master/docs/from_bosh_to_kube.md#example-deployment-manifest-conversion-details) example manifest. I am happy to change it to another location, if it makes sense to be placed at a different spot.

## Test plan

In the `release` stanza of the `values.yaml`, for example configure a stemcell with a private registry location:
```yaml
releases:
  defaults:
    url: private.registry.io/foobar
    stemcell:
      os: BeOS
      version: 5.0.3-7.0.0_355.gd4df8ff7
  credentials:
    hostname: private.registry.io
    username: token
```

During the Helm based install, provide the secret:
```sh
helm install
  --namespace scf \
  --name scf \
  scf-3.0.0.tgz
  --set "releases.credentials.password="$(vault read /super/secret)"
```

Eventually, this should create a simple secret usable for pulling images:
```
kubectl -n scf get secret registry-credentials
NAME                   TYPE                             DATA   AGE
registry-credentials   kubernetes.io/dockerconfigjson   1      111s
```
