### PR TITLE
Add OS switch in UAA pre-start patch

### DIFF
--- a/bosh/releases/pre_render_scripts/uaa/uaa/jobs/patch_pre-start.sh
+++ b/bosh/releases/pre_render_scripts/uaa/uaa/jobs/patch_pre-start.sh
@@ -6,16 +6,39 @@ target="/var/vcap/all-releases/jobs-src/uaa/uaa/templates/bin/pre-start.erb"
 
 # Patch bin/pre-start.erb for the certificates to work with SUSE.
 PATCH=$(cat <<'EOT'
-24c24
-< rm -f /usr/local/share/ca-certificates/uaa_*
----
-> rm -f /etc/pki/trust/anchors/uaa_*
-26,27c26,27
-<     echo "Adding certificate from manifest to OS certs /usr/local/share/ca-certificates/uaa_<%= i %>.crt"
-<     echo -n '<%= cert %>' >> "/usr/local/share/ca-certificates/uaa_<%= i %>.crt"
----
->     echo "Adding certificate from manifest to OS certs /etc/pki/trust/anchors/uaa_<%= i %>.crt"
->     echo -n '<%= cert %>' >> "/etc/pki/trust/anchors/uaa_<%= i %>.crt"
+--- pre-start.erb	2019-11-05 10:53:19.000000000 +0100
++++ -	2019-11-05 10:59:27.000000000 +0100
+@@ -21,11 +21,29 @@
+ }
+
+ # add certs from manifest to OS certs
+-rm -f /usr/local/share/ca-certificates/uaa_*
++source /etc/os-release
++case "${ID}" in
++  *ubuntu*)
++    rm -f /usr/local/share/ca-certificates/uaa_*
+ <% p('uaa.ca_certs', []).each_with_index do |cert, i| %>
+     echo "Adding certificate from manifest to OS certs /usr/local/share/ca-certificates/uaa_<%= i %>.crt"
+     echo -n '<%= cert %>' >> "/usr/local/share/ca-certificates/uaa_<%= i %>.crt"
+ <% end %>
++  ;;
++
++  *suse*)
++    rm -f /etc/pki/trust/anchors/uaa_*
++<% p('uaa.ca_certs', []).each_with_index do |cert, i| %>
++    echo "Adding certificate from manifest to OS certs /etc/pki/trust/anchors/uaa_<%= i %>.crt"
++    echo -n '<%= cert %>' >> "/etc/pki/trust/anchors/uaa_<%= i %>.crt"
++<% end %>
++  ;;
++
++  *)
++  echo "Unsupported operating system: ${PRETTY_NAME}"
++  exit 42
++  ;;
++esac
+
+ update_ca_certificate
+
 EOT
 )
 


### PR DESCRIPTION
## Description
In case a different stemcell is used, for example Ubuntu, some patches are no
longer valid for specific BOSH releases. There was an issue that the patch for
the CA certificate location failed to work on Ubuntu based images.

Initially, we tried to enhance the OS specific patches, by getting the operative
system ID, in order to skip the patch in a non SUSE OS. We realized that this wouldn´t
properly work, while the patch is evaluated under the cf-operator img, which is build
based on openSUSE. We could have try to improve the patch by other means, but this already
looks too complicated, and a feature flag will simplify the desired goal.

Introduce a feature flag called `suse_stemcell`, which adds another ops file to
the list of ops files referenced by the BOSHDeployment CRD.

This would enable `kubecf` to add more OS specific patches in the same directory
in the future.

## Motivation and Context
Kubecf should support a CF distribution based on both SUSE and Ubuntu stemcells.

## How Has This Been Tested?
We have an internal pipeline that builds Ubuntu based images(bosh releases), and we have use them, to deploy internally, into an IBM IKS cluster.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
