### PR TITLE
Reverted the removal of global namespace

### DIFF
--- a/def.bzl
+++ b/def.bzl
@@ -1,4 +1,5 @@
 project = struct(
+    namespace = "kubecf",
     cf_deployment = struct(
         version = "8.0.0",
         sha256 = "289f6c5a116eef4b16b228d07d55517dc20f76199c1476036fc0ade5a08a3e1b",

--- a/dev/scf/BUILD.bazel
+++ b/dev/scf/BUILD.bazel
@@ -8,18 +8,18 @@ helm_template(
     name = "rendered_template",
     values = glob(["**/*values.yaml"]),
     install_name = "scf",
-    namespace = "${KUBECF_NAMESPACE}",
+    namespace = project.namespace,
     chart_package = "//deploy/helm/scf:chart",
 )
 
 kubectl_apply_binary(
     name = "apply",
     resource = ":rendered_template",
-    namespace = "${KUBECF_NAMESPACE}",
+    namespace = project.namespace,
 )
 
 kubectl_delete_binary(
     name = "delete",
     resource = ":rendered_template",
-    namespace = "${KUBECF_NAMESPACE}",
+    namespace = project.namespace,
 )

--- a/testing/acceptance_tests/BUILD.bazel
+++ b/testing/acceptance_tests/BUILD.bazel
@@ -5,7 +5,7 @@ load("//:def.bzl", "project")
 
 kubectl_patch(
     name = "acceptance_tests",
-    namespace = "${KUBECF_NAMESPACE}",
+    namespace = project.namespace,
     resource_type = "ejob",
     resource_name = "scf-acceptance-tests",
     patch_type = "merge",

--- a/testing/smoke_tests/BUILD.bazel
+++ b/testing/smoke_tests/BUILD.bazel
@@ -7,7 +7,7 @@ load("//:def.bzl", "project")
 # kubectl_patch script as a dependency.
 kubectl_patch(
     name = "smoke_tests",
-    namespace = "${KUBECF_NAMESPACE}",
+    namespace = project.namespace,
     resource_type = "ejob",
     resource_name = "scf-smoke-tests",
     patch_type = "merge",


### PR DESCRIPTION
By removing the global namespace, I broke the build rules that depended on it.