### PR TITLE
acceptance-tests: bump to BOSH release 0.0.2

### DIFF
--- a/deploy/helm/kubecf/assets/operations/instance_groups/acceptance-tests.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/acceptance-tests.yaml
@@ -3,7 +3,7 @@
   value:
     name: cf-acceptance-tests
     url: {{ .Values.releases.defaults.url | quote }}
-    version: 0.0.1
+    version: 0.0.2
 - path: /instance_groups/-
   type: replace
   value:

--- a/deploy/helm/kubecf/assets/operations/temporary/cf-acceptance-tests-stemcell.yaml
+++ b/deploy/helm/kubecf/assets/operations/temporary/cf-acceptance-tests-stemcell.yaml
@@ -6,4 +6,4 @@
   value:
       alias: default
       os: opensuse-42.3
-      version: 36.g03b4653-30.80-7.0.0_355.gd4df8ff7
+      version: 36.g03b4653-30.80-7.0.0_360.g0ec8d681


### PR DESCRIPTION
## Description
The bumps the [cf-acceptance-tests-release](https://github.com/SUSE/cf-acceptance-tests-release/) to 0.0.2.

## Motivation and Context
This adds the `cf tail` plugin, which makes many tests pass.

## How Has This Been Tested?
Run CATS locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
