### PR TITLE
CATS: Fix API endpoint

### DIFF
--- a/deploy/helm/kubecf/assets/operations/instance_groups/acceptance-tests.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/acceptance-tests.yaml
@@ -16,7 +16,7 @@
         acceptance_tests:
           admin_password: ((cf_admin_password))
           admin_user: admin
-          api: https://api.((system_domain))
+          api: api.((system_domain))
           apps_domain: ((system_domain))
           skip_ssl_validation: true
         bpm:

--- a/deploy/helm/kubecf/assets/operations/instance_groups/acceptance-tests.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/acceptance-tests.yaml
@@ -3,7 +3,7 @@
   value:
     name: cf-acceptance-tests
     url: {{ .Values.releases.defaults.url | quote }}
-    version: 0.0.2
+    version: 0.0.3
 - path: /instance_groups/-
   type: replace
   value:


### PR DESCRIPTION
## Description
The tests expect the endpoint to not include the scheme (`https://`); this is causing some test failures.  Fix that.
Also, drop the logs container for the CATS & smoke tests pods, since they are BOSH errands.  The logs container was pointlessly holding the pods alive (since they never complete).

## How Has This Been Tested?
Ran CATS locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
