### PR TITLE
Replace hardcoded stemcell settings with template reference

### DIFF
--- a/deploy/helm/kubecf/assets/operations/instance_groups/bits.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/bits.yaml
@@ -10,10 +10,7 @@
   path: /releases/name=bits-service/sha1
 - type: replace
   path: /releases/name=bits-service/stemcell?
-  value:
-    alias: default
-    os: opensuse-42.3
-    version: 36.g03b4653-30.80-7.0.0_348.gc8fb3864
+  value: {{ include "kubecf.stemcellLookup" (list .Values.releases "bits-service") }}
 
 # Add quarks information to the Bits Service jobs.
 - type: replace

--- a/deploy/helm/kubecf/assets/operations/instance_groups/database.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/database.yaml
@@ -11,7 +11,7 @@
   path: /releases/name=cf-mysql?
   value:
     name: cf-mysql
-    url: docker.io/cfcontainerization
+    url: {{ .Values.releases.defaults.url | quote }}
     version: 36.19.0
     sha1: ~
 

--- a/deploy/helm/kubecf/assets/operations/instance_groups/eirini.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/eirini.yaml
@@ -136,10 +136,7 @@
     name: eirini
     version: 0.0.22
     url: {{ .Values.releases.defaults.url | quote }}
-    stemcell:
-      alias: default
-      os: opensuse-42.3
-      version: 36.g03b4653-30.80-7.0.0_360.g0ec8d681
+    stemcell: {{ include "kubecf.stemcellLookup" (list .Values.releases "eirini") }}
 
 # Set the correct addresses to be reached by the Eirini apps namespace.
 - type: replace

--- a/deploy/helm/kubecf/templates/_helpers.tpl
+++ b/deploy/helm/kubecf/templates/_helpers.tpl
@@ -77,3 +77,27 @@ flattened and separated by `separator`.
     {{- $_ := set $flattened $key $value }}
   {{- end }}
 {{- end -}}
+
+{{/*
+Returns a JSON map with the stemcell information based on the defaults
+and possible overrides for the respective release.
+*/}}
+{{- define "kubecf.stemcellLookup" -}}
+  {{- $releasesMap := index . 0 }}
+  {{- $releaseName := index . 1 }}
+  {{- $result := dict  "os" (index $releasesMap "defaults" "stemcell" "os")  "version" (index $releasesMap "defaults" "stemcell" "version") }}
+
+  {{- if index $releasesMap $releaseName }}
+    {{- if index $releasesMap $releaseName "stemcell" }}
+      {{- if index $releasesMap $releaseName "stemcell" "os" }}
+        {{- $_ := set $result "os" (index $releasesMap $releaseName "stemcell" "os") }}
+      {{- end }}
+
+      {{- if index $releasesMap $releaseName "stemcell" "version" }}
+        {{- $_ := set $result "version" (index $releasesMap $releaseName "stemcell" "version") }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+
+  {{- toJson $result }}
+{{- end -}}

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -20,6 +20,14 @@ releases:
       os: opensuse-42.3
       version: 36.g03b4653-30.80-7.0.0_340.g2b599a90
 
+  bits-service:
+    stemcell:
+      version: 36.g03b4653-30.80-7.0.0_348.gc8fb3864
+
+  eirini:
+    stemcell:
+      version: 36.g03b4653-30.80-7.0.0_360.g0ec8d681
+
 sizing:
   HA: false
 


### PR DESCRIPTION
## Description
Allow for a simple change of the stemcell at one spot in the configuration and avoid duplication in configuration.

**Please note:** I realized that different stemcell versions (to be more precise, different fissile versions) were used, for example in `eirini.yaml`, the configured version was `36.g03b4653-30.80-7.0.0_360.g0ec8d681` whereas in the `values.yaml`, it is `36.g03b4653-30.80-7.0.0_340.g2b599a90`. Having only one spot where you define the stemcell version also means that a common fissile version is enforced. However, it looks like there are missing images for some combinations of fissile and BOSH releases, for example when trying to bump to fissile `7.0.0_360.g0ec8d681`.

## Motivation and Context
When trying to switch to another stemcell, there are multiple sections in `kubecf` that need to be modified.

Therefore, replace hardcoded openSUSE references with the Go template that uses the input from the `values.yaml` to populate the respective fields.

This way, one can simply overwrite the stemcell related settings in the `values.yaml` and the rest should fall into place.

## How Has This Been Tested?
Performed a deployment with the openSUSE stemcell against an IBM Kubernetes service cluster as well as a deployment with an Ubuntu based stemcell. Like mentioned before, I was only able to test with Eirini disabled, because with Eirini it seems that fissile needs to be bumped to `7.0.0_360.g0ec8d681` for all other BOSH releases. For example, it seems that `cfcontainerization/capi:opensuse-42.3-36.g03b4653-30.80-7.0.0_360.g0ec8d681-1.83.0` does not exist at the moment.

## Screenshots (if appropriate):
n/a

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code has security implications.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
