### PR TITLE
UAA: Force TLS between UAA and gorouter

### DIFF
--- a/deploy/helm/kubecf/assets/operations/instance_groups/router.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/router.yaml
@@ -29,6 +29,14 @@
       exec:
         command: [sh, -c, 'ss -nlu sport = 3457 | grep :3457']
 
+# Add UAA CA cert to the router so the router -> UAA traffic can be encrypted
+- type: replace
+  path: /instance_groups/name=router/jobs/name=gorouter/properties/router/ca_certs
+  value: |
+    ((application_ca.certificate))
+    ((service_cf_internal_ca.certificate))
+    ((uaa_ca.certificate))
+
 # Add necessary labels to the router instance group so that the service can select it to create the
 # endpoint.
 - type: replace

--- a/deploy/helm/kubecf/assets/operations/instance_groups/uaa.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/uaa.yaml
@@ -20,6 +20,14 @@
     post_start:
       condition: *uaa_readiness
 
+# Use TLS for router to UAA traffic
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=route_registrar/properties/route_registrar/routes/name=uaa/tls_port?
+  value: 8443
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=route_registrar/properties/route_registrar/routes/name=uaa/server_cert_domain_san?
+  value: uaa.service.cf.internal
+
 - type: replace
   path: /instance_groups/name=uaa/jobs/name=route_registrar/properties/quarks?/run/healthcheck/route_registrar
   value:


### PR DESCRIPTION
## Description
This makes the traffic between UAA and gorouter be encrypted, so that we can get fully encrypted traffic from the user to UAA (though it's decrypted and re-encrypted a few times in between).

This does _not_ do mTLS.

## Motivation and Context
This is related to (but does not completely overlap) #106

## How Has This Been Tested?
Ran smoke tests locally, and deployed an app (see #106 for my configuration when testing this; ingress + SSL).

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
