### PR TITLE
Eirini has now a dependency to nats and should be started after the s…

### DIFF
--- a/deploy/helm/kubecf/assets/operations/instance_groups/eirini.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/eirini.yaml
@@ -13,7 +13,7 @@
       query: '*'
 
 - type: replace
-  path: /instance_groups/0:before
+  path: /instance_groups/name=nats:after
   value:
     name: configure-eirini
     lifecycle: auto-errand
@@ -60,12 +60,14 @@
 
 # Add eirini
 - type: replace
-  path: /instance_groups/0:after
+  path: /instance_groups/name=configure-eirini:after
   value:
     name: eirini
     release: eirini
     instances: 1
     stemcell: default
+    update:
+      serial: true
     env:
       bosh:
         agent:


### PR DESCRIPTION
…ervice is available.

With newer versions of cf-operator, this will otherwise result in a deadlock since `eirini`
waits for `nats` to be ready and `nats` indirectly waits for `eirini`

Co-authored-by: Philipp Stehle <philipp.stehle@sap.com>

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
With newer version of `cf-operator` respecting the order of a bosh deployment und newer version of `eirini` to have a dependency to `nats` in order to start, this resulted in a deadlock with hardly any pod starting up.

## How Has This Been Tested?
Manually by installing with the latest `cf-operator`.

And all pods start up.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
