### PR TITLE
Fixed property to disable Eirini cert-copier

### DIFF
--- a/deploy/helm/kubecf/assets/operations/instance_groups/eirini.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/eirini.yaml
@@ -43,9 +43,6 @@
             mutual_tls:
               server_cert: "((cc_bridge_cc_uploader_server.certificate))"
               server_key: "((cc_bridge_cc_uploader_server.private_key))"
-        eirini:
-          run_cert_copier: ~
-          cert_copier_image: ""
         opi:
           registry_address: 127.0.0.1:{{ .Values.features.eirini.registry.service.nodePort }}
           kube_namespace: {{ .Values.deployment_name }}-eirini


### PR DESCRIPTION
## Description

After https://github.com/cloudfoundry-community/eirini-bosh-release/commit/f2856a00bdc234e3437bff61888b5d5df64e4dc4#diff-003fe3ee396141e33a6c6bf3d8e84618, the property `eirini.run_cert_copier` doesn't exist anymore. We have to rely on `eirini.cert_copier_image` now.

## How Has This Been Tested?

Manually watching for the `configure-eirini` errand.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
