### PR TITLE
Annotate operator chart url in Chart.yaml

### DIFF
--- a/deploy/helm/kubecf/BUILD.bazel
+++ b/deploy/helm/kubecf/BUILD.bazel
@@ -2,12 +2,23 @@ package(default_visibility = ["//visibility:public"])
 
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("//rules/helm:def.bzl", helm_package = "package")
+load("//:def.bzl", "project")
+load("//deploy/helm/kubecf:defs.bzl", "metadata_file_generator")
+
+metadata_file_generator(
+    name = "metadata",
+    file = "Metadata.yaml",
+    operator_chart = project.cf_operator.chart.url
+)
 
 filegroup(
     name = "chart_files_static",
     srcs = glob(
         ["**/*"],
-        exclude = ["**/BUILD.bazel"],
+        exclude = [
+            "**/BUILD.bazel",
+            "**/defs.bzl",
+        ],
     ),
 )
 
@@ -23,6 +34,9 @@ helm_package(
     name = "chart",
     srcs = [
         ":chart_files_static",
+    ],
+    generated = [
+        ":metadata",
     ],
     tars = [
         ":cf_deployment",

--- a/deploy/helm/kubecf/defs.bzl
+++ b/deploy/helm/kubecf/defs.bzl
@@ -1,0 +1,8 @@
+def metadata_file_generator(name, file, operator_chart, visibility=None):
+  native.genrule(
+    name = name,
+    srcs = [],
+    outs = [file],
+    cmd = "echo 'operatorChartUrl: \"{}\"' > $@".format(operator_chart),
+    visibility = visibility,
+  )

--- a/rules/helm/def.bzl
+++ b/rules/helm/def.bzl
@@ -3,7 +3,7 @@ def _package_impl(ctx):
     output_tgz = ctx.actions.declare_file(output_filename)
     outputs = [output_tgz]
     ctx.actions.run(
-        inputs = [] + ctx.files.srcs + ctx.files.tars,
+        inputs = [] + ctx.files.srcs + ctx.files.tars + ctx.files.generated,
         outputs = outputs,
         tools = [ctx.executable._helm],
         progress_message = "Generating Helm package archive {}".format(output_filename),
@@ -12,6 +12,8 @@ def _package_impl(ctx):
             "PACKAGE_DIR": ctx.attr.package_dir,
             # TODO(f0rmiga): Figure out a way of working with paths that contain spaces.
             "TARS": " ".join([f.path for f in ctx.files.tars]),
+            # TODO(mudler): Support also nested folders and paths with spaces
+            "GENERATED": " ".join([f.path for f in ctx.files.generated]),
             "HELM": ctx.executable._helm.path,
             "CHART_VERSION": ctx.attr.chart_version,
             "APP_VERSION": ctx.attr.app_version,
@@ -27,6 +29,7 @@ _package = rule(
         "srcs": attr.label_list(
             mandatory = True,
         ),
+        "generated": attr.label_list(),
         "tars": attr.label_list(),
         "package_dir": attr.string(
             mandatory = True,

--- a/rules/helm/package.sh
+++ b/rules/helm/package.sh
@@ -4,10 +4,17 @@ set -o errexit -o nounset
 
 build_dir="tmp/build/${PACKAGE_DIR}"
 mkdir -p "${build_dir}"
+
 cp -L -R "${PACKAGE_DIR}"/* "${build_dir}"
 
+# Generated files ( here TARS, GENERATED ) are not part of the source code
+# to be able to use them, we have to copy them
 for t in ${TARS}; do
-  tar xf "${t}" -C "${build_dir}"
+  tar xf "${t}" -C "${build_dir}"  > /dev/null
+done
+
+for g in ${GENERATED}; do
+  cp "${g}" "${build_dir}"/ > /dev/null
 done
 
 "${HELM}" init --client-only > /dev/null


### PR DESCRIPTION
With this change, the bazel helm package stage will inject a new file in the `Metadata.yaml`, with a new key, `operatorChartUrl` with the project defined operator chart url in https://github.com/SUSE/kubecf/blob/3ebba68fbb03fd72df962d67d168a52419c05198/def.bzl#L9.

In this way we don't have to repackage the chart to inject a value in `Chart.yaml`, which is being generated by helm.

## Motivation and Context
We have a reference between the chart generated and the operator version needed to deploy it  #124 

## How Has This Been Tested?
Locally and with Catapult, see https://github.com/SUSE/catapult/pull/76


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
