### PR TITLE
Let the user configure the storage class used for components

### DIFF
--- a/deploy/helm/kubecf/assets/operations/instance_groups/bits.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/bits.yaml
@@ -50,13 +50,14 @@
   value: local
 
 # Attach a persistent disk to bits-service VM to store eirinifs
-# TODO: storage class type should be configurable
-# - type: replace
-#   path: /instance_groups/name=bits/persistent_disk_type?
-#   value: ???
 - type: replace
   path: /instance_groups/name=bits/persistent_disk?
   value: 20480 # 20GB
+{{- if .Values.kube.storage_class }}
+- type: replace
+  path: /instance_groups/name=bits/persistent_disk_type?
+  value: {{ .Values.kube.storage_class }}
+{{- end }}
 
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/bits_service?/enabled?

--- a/deploy/helm/kubecf/assets/operations/instance_groups/database.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/database.yaml
@@ -16,11 +16,14 @@
     sha1: ~
 
 # Configure the persistent disk in the way that cf-operator can provision.
-- type: remove
-  path: /instance_groups/name=database/persistent_disk_type
 - type: replace
   path: /instance_groups/name=database/persistent_disk?
   value: 20480 # 20GB
+{{- if .Values.kube.storage_class }}
+- type: replace
+  path: /instance_groups/name=database/persistent_disk_type
+  value: {{ .Values.kube.storage_class }}
+{{- end }}
 
 # Replace the jobs using the cf-mysql-release.
 - type: replace

--- a/deploy/helm/kubecf/assets/operations/instance_groups/singleton-blobstore.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/singleton-blobstore.yaml
@@ -1,9 +1,11 @@
-# Configure the persistent disk in the way that cf-operator can provision.
-- type: remove
-  path: /instance_groups/name=singleton-blobstore/persistent_disk_type
 - type: replace
   path: /instance_groups/name=singleton-blobstore/persistent_disk?
   value: 102400 # 100GB
+{{- if .Values.kube.storage_class }}
+- type: replace
+  path: /instance_groups/name=singleton-blobstore/persistent_disk_type
+  value: {{ .Values.kube.storage_class }}
+{{- end }}
 
 - type: replace
   path: /instance_groups/name=singleton-blobstore/jobs/name=blobstore/properties/blobstore/internal_access_rules?

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -12,6 +12,11 @@ deployment_name: kubecf
 #              addr: kubecf-log-api:8082
 properties: {}
 
+# The the storage class to be used for the instance groups that need it (e.g. bits, database and singleton-blobstore)
+# If it's not set, the default storage class will be used.
+kube:
+  storage_class: ~
+
 releases:
   # The defaults for all releases, where we do not otherwise override them.
   defaults:


### PR DESCRIPTION
Resolves #26

Any idea which docs I should update?

## How Has This Been Tested?
Deployed on kind with this in my values file:

```
kube:
  storage_class: custom
```
pvcs were created on the `custom` storageclass (which was not the default)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
