### PR TITLE
ingress: fix ingress template

### DIFF
--- a/deploy/helm/kubecf/templates/ingress.yaml
+++ b/deploy/helm/kubecf/templates/ingress.yaml
@@ -22,7 +22,7 @@ metadata:
 data:
   tls.crt: {{ .Values.features.ingress.tls.crt | b64enc | quote }}
   tls.key: {{ .Values.features.ingress.tls.key | b64enc | quote }}
-{{- end -}}
+{{- end }}
 ---
 # This ingress specifies routing and access for the cloud controller public Kubecf service, e.g.
 # "api.<domain>" and other services in that domain hierarchy.


### PR DESCRIPTION
## Description
Removing the whitespace at the end of the conditional ended up with the next line stuck to the previous line, producing invalid YAML.

## Motivation and Context
`bazel run //dev/kubecf:apply` was failing

## How Has This Been Tested?
Deployed again with ingress (on minikube).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
