### PR TITLE
Use external database

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -89,3 +89,9 @@ filegroup(
     strip_prefix = "metrics-server-{}".format(project.metrics_server.version),
     url = "https://github.com/kubernetes-incubator/metrics-server/archive/v{}.tar.gz".format(project.metrics_server.version),
 )
+
+http_file(
+    name = "mysql_chart",
+    sha256 = project.mysql_chart.sha256,
+    urls = ["https://kubernetes-charts.storage.googleapis.com/mysql-{}.tgz".format(project.mysql_chart.version)],
+)

--- a/def.bzl
+++ b/def.bzl
@@ -6,8 +6,8 @@ project = struct(
     ),
     cf_operator = struct(
         chart = struct(
-            url = "https://s3.amazonaws.com/cf-operators/helm-charts/cf-operator-v0.4.2-147.gb88e4296.tgz",
-            sha256 = "7cc0c23df3aa5fb7f2075e3dbd77d2dc51c1ee283060ae9cb46ed680b1deb1d0",
+            url = "https://s3.amazonaws.com/cf-operators/helm-charts/cf-operator-v0.4.2-167.g34209e10.tgz",
+            sha256 = "9ecdb9b452d41dd83a070179b14333054b558daec923d58e29f96ced4af4e208",
         ),
         namespace = "cfo",
     ),

--- a/def.bzl
+++ b/def.bzl
@@ -112,4 +112,8 @@ project = struct(
             },
         ),
     ),
+    mysql_chart = struct(
+        version = "1.3.3",
+        sha256 = "9ef4ce3693eb2a7428598f9dae833ee546eac9c105b4005c6d7375c55e33bdff",
+    ),
 )

--- a/deploy/helm/kubecf/assets/operations/instance_groups/database.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/database.yaml
@@ -170,6 +170,8 @@
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/ccdb/roles/name=cloud_controller/name
   value: *external_cc_database_username
+- type: remove
+  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/ccdb/ca_cert?
 
 - type: replace
   path: /instance_groups/name=diego-api/jobs/name=bbs/properties/diego/bbs/sql/db_driver

--- a/deploy/helm/kubecf/assets/operations/instance_groups/database.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/database.yaml
@@ -1,3 +1,323 @@
+{{- if .Values.features.external_database.enabled -}}
+
+# Remove the database instance group and release.
+- type: remove
+  path: /instance_groups/name=database
+- type: remove
+  path: /releases/name=pxc
+
+# Remove the database variables.
+- type: remove
+  path: /variables/name=cf_mysql_mysql_admin_password
+- type: remove
+  path: /variables/name=cf_mysql_mysql_cluster_health_password
+- type: remove
+  path: /variables/name=cf_mysql_mysql_galera_healthcheck_endpoint_password
+- type: remove
+  path: /variables/name=cf_mysql_mysql_galera_healthcheck_password
+- type: remove
+  path: /variables/name=cf_mysql_proxy_api_password
+- type: remove
+  path: /variables/name=network_policy_database_password
+- type: remove
+  path: /variables/name=network_connectivity_database_password
+- type: remove
+  path: /variables/name=routing_api_database_password
+- type: remove
+  path: /variables/name=locket_database_password
+- type: remove
+  path: /variables/name=cc_database_password
+- type: remove
+  path: /variables/name=credhub_database_password
+- type: remove
+  path: /variables/name=diego_database_password
+- type: remove
+  path: /variables/name=uaa_database_password
+- type: remove
+  path: /variables/name=pxc_galera_ca
+- type: remove
+  path: /variables/name=pxc_server_ca
+- type: remove
+  path: /variables/name=galera_server_certificate
+- type: remove
+  path: /variables/name=mysql_server_certificate
+
+# Remove database links.
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/consumes?
+  value: {database: nil}
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/consumes?
+  value: {database: nil}
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/consumes?
+  value: {database: nil}
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/consumes?
+  value: {database: nil}
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/consumes?
+  value: {database: nil}
+- type: replace
+  path: /instance_groups/name=diego-api/jobs/name=silk-controller/consumes?
+  value: {database: nil}
+- type: replace
+  path: /instance_groups/name=api/jobs/name=policy-server/consumes?
+  value: {database: nil}
+
+# Replace database config for the jobs.
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaadb/db_scheme
+  value: {{ .Values.features.external_database.type | quote }}
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaadb/port
+  value: {{ .Values.features.external_database.port }}
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaadb/databases/tag=uaa/name
+  value: {{ .Values.features.external_database.databases.uaa.name | quote }}
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaadb/address?
+  value: {{ .Values.features.external_database.host | quote }}
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaadb/roles/name=uaa/password
+  value: {{ .Values.features.external_database.databases.uaa.password | quote }}
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaadb/roles/name=uaa/name
+  value: {{ .Values.features.external_database.databases.uaa.username | quote }}
+- type: remove
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa?/ca_certs
+- type: remove
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaadb/tls_enabled?
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/ccdb/db_scheme
+  value: &external_cc_database_scheme {{ .Values.features.external_database.type | quote }}
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/ccdb/port
+  value: &external_cc_database_port {{ .Values.features.external_database.port }}
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/ccdb/databases/tag=cc/name
+  value: &external_cc_database_name {{ .Values.features.external_database.databases.cc.name | quote }}
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/ccdb/address?
+  value: &external_cc_database_address {{ .Values.features.external_database.host | quote }}
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/ccdb/roles/name=cloud_controller/password
+  value: &external_cc_database_password {{ .Values.features.external_database.databases.cc.password | quote }}
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/ccdb/roles/name=cloud_controller/name
+  value: &external_cc_database_username {{ .Values.features.external_database.databases.cc.username | quote }}
+- type: remove
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/ccdb/ca_cert?
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/ccdb/db_scheme
+  value: *external_cc_database_scheme
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/ccdb/port
+  value: *external_cc_database_port
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/ccdb/databases/tag=cc/name
+  value: *external_cc_database_name
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/ccdb/address?
+  value: *external_cc_database_address
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/ccdb/roles/name=cloud_controller/password
+  value: *external_cc_database_password
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/ccdb/roles/name=cloud_controller/name
+  value: *external_cc_database_username
+- type: remove
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/ccdb/ca_cert?
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/ccdb/db_scheme
+  value: *external_cc_database_scheme
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/ccdb/port
+  value: *external_cc_database_port
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/ccdb/databases/tag=cc/name
+  value: *external_cc_database_name
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/ccdb/address?
+  value: *external_cc_database_address
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/ccdb/roles/name=cloud_controller/password
+  value: *external_cc_database_password
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/ccdb/roles/name=cloud_controller/name
+  value: *external_cc_database_username
+- type: remove
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/ccdb/ca_cert?
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/ccdb/db_scheme
+  value: *external_cc_database_scheme
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/ccdb/port
+  value: *external_cc_database_port
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/ccdb/databases/tag=cc/name
+  value: *external_cc_database_name
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/ccdb/address?
+  value: *external_cc_database_address
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/ccdb/roles/name=cloud_controller/password
+  value: *external_cc_database_password
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/ccdb/roles/name=cloud_controller/name
+  value: *external_cc_database_username
+
+- type: replace
+  path: /instance_groups/name=diego-api/jobs/name=bbs/properties/diego/bbs/sql/db_driver
+  value: {{ .Values.features.external_database.type | quote }}
+- type: replace
+  path: /instance_groups/name=diego-api/jobs/name=bbs/properties/diego/bbs/sql/db_port
+  value: {{ .Values.features.external_database.port }}
+- type: replace
+  path: /instance_groups/name=diego-api/jobs/name=bbs/properties/diego/bbs/sql/db_schema
+  value: {{ .Values.features.external_database.databases.bbs.name | quote }}
+- type: replace
+  path: /instance_groups/name=diego-api/jobs/name=bbs/properties/diego/bbs/sql/db_host?
+  value: {{ .Values.features.external_database.host | quote }}
+- type: replace
+  path: /instance_groups/name=diego-api/jobs/name=bbs/properties/diego/bbs/sql/db_password
+  value: {{ .Values.features.external_database.databases.bbs.password | quote }}
+- type: replace
+  path: /instance_groups/name=diego-api/jobs/name=bbs/properties/diego/bbs/sql/db_username
+  value: {{ .Values.features.external_database.databases.bbs.username | quote }}
+- type: remove
+  path: /instance_groups/name=diego-api/jobs/name=bbs/properties/diego/bbs/sql/ca_cert?
+- type: remove
+  path: /instance_groups/name=diego-api/jobs/name=bbs/properties/diego/bbs/sql/require_ssl?
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=routing-api/properties/routing_api/sqldb/type
+  value: {{ .Values.features.external_database.type | quote }}
+- type: replace
+  path: /instance_groups/name=api/jobs/name=routing-api/properties/routing_api/sqldb/port
+  value: {{ .Values.features.external_database.port }}
+- type: replace
+  path: /instance_groups/name=api/jobs/name=routing-api/properties/routing_api/sqldb/schema
+  value: {{ .Values.features.external_database.databases.routing_api.name | quote }}
+- type: replace
+  path: /instance_groups/name=api/jobs/name=routing-api/properties/routing_api/sqldb/host?
+  value: {{ .Values.features.external_database.host | quote }}
+- type: replace
+  path: /instance_groups/name=api/jobs/name=routing-api/properties/routing_api/sqldb/password
+  value: {{ .Values.features.external_database.databases.routing_api.password | quote }}
+- type: replace
+  path: /instance_groups/name=api/jobs/name=routing-api/properties/routing_api/sqldb/username
+  value: {{ .Values.features.external_database.databases.routing_api.username | quote }}
+- type: remove
+  path: /instance_groups/name=api/jobs/name=routing-api/properties/routing_api/sqldb/ca_cert?
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=policy-server/properties/database/type
+  value: {{ .Values.features.external_database.type | quote }}
+- type: replace
+  path: /instance_groups/name=api/jobs/name=policy-server/properties/database/port
+  value: {{ .Values.features.external_database.port }}
+- type: replace
+  path: /instance_groups/name=api/jobs/name=policy-server/properties/database/name
+  value: {{ .Values.features.external_database.databases.policy_server.name | quote }}
+- type: replace
+  path: /instance_groups/name=api/jobs/name=policy-server/properties/database/host
+  value: {{ .Values.features.external_database.host | quote }}
+- type: replace
+  path: /instance_groups/name=api/jobs/name=policy-server/properties/database/password
+  value: {{ .Values.features.external_database.databases.policy_server.password | quote }}
+- type: replace
+  path: /instance_groups/name=api/jobs/name=policy-server/properties/database/username
+  value: {{ .Values.features.external_database.databases.policy_server.username | quote }}
+- type: remove
+  path: /instance_groups/name=api/jobs/name=policy-server/properties/database/ca_cert?
+- type: remove
+  path: /instance_groups/name=api/jobs/name=policy-server/properties/database/require_ssl?
+
+- type: replace
+  path: /instance_groups/name=diego-api/jobs/name=silk-controller/properties/database/type
+  value: {{ .Values.features.external_database.type | quote }}
+- type: replace
+  path: /instance_groups/name=diego-api/jobs/name=silk-controller/properties/database/port
+  value: {{ .Values.features.external_database.port }}
+- type: replace
+  path: /instance_groups/name=diego-api/jobs/name=silk-controller/properties/database/name
+  value: {{ .Values.features.external_database.databases.silk_controller.name | quote }}
+- type: replace
+  path: /instance_groups/name=diego-api/jobs/name=silk-controller/properties/database/host
+  value: {{ .Values.features.external_database.host | quote }}
+- type: replace
+  path: /instance_groups/name=diego-api/jobs/name=silk-controller/properties/database/password
+  value: {{ .Values.features.external_database.databases.silk_controller.password | quote }}
+- type: replace
+  path: /instance_groups/name=diego-api/jobs/name=silk-controller/properties/database/username
+  value: {{ .Values.features.external_database.databases.silk_controller.username | quote }}
+- type: remove
+  path: /instance_groups/name=diego-api/jobs/name=silk-controller/properties/database/ca_cert?
+- type: remove
+  path: /instance_groups/name=diego-api/jobs/name=silk-controller/properties/database/require_ssl?
+
+- type: replace
+  path: /instance_groups/name=diego-api/jobs/name=locket/properties/diego/locket/sql/db_driver
+  value: {{ .Values.features.external_database.type | quote }}
+- type: replace
+  path: /instance_groups/name=diego-api/jobs/name=locket/properties/diego/locket/sql/db_port
+  value: {{ .Values.features.external_database.port }}
+- type: replace
+  path: /instance_groups/name=diego-api/jobs/name=locket/properties/diego/locket/sql/db_schema
+  value: {{ .Values.features.external_database.databases.locket.name | quote }}
+- type: replace
+  path: /instance_groups/name=diego-api/jobs/name=locket/properties/diego/locket/sql/db_host?
+  value: {{ .Values.features.external_database.host | quote }}
+- type: replace
+  path: /instance_groups/name=diego-api/jobs/name=locket/properties/diego/locket/sql/db_password
+  value: {{ .Values.features.external_database.databases.locket.password | quote }}
+- type: replace
+  path: /instance_groups/name=diego-api/jobs/name=locket/properties/diego/locket/sql/db_username
+  value: {{ .Values.features.external_database.databases.locket.username | quote }}
+- type: remove
+  path: /instance_groups/name=diego-api/jobs/name=locket/properties/diego/locket/sql/ca_cert?
+- type: remove
+  path: /instance_groups/name=diego-api/jobs/name=locket/properties/diego/locket/sql/require_ssl?
+
+- type: replace
+  path: /instance_groups/name=credhub/jobs/name=credhub/properties/credhub/data_storage/type
+  value: {{ .Values.features.external_database.type | quote }}
+- type: replace
+  path: /instance_groups/name=credhub/jobs/name=credhub/properties/credhub/data_storage/port
+  value: {{ .Values.features.external_database.port }}
+- type: replace
+  path: /instance_groups/name=credhub/jobs/name=credhub/properties/credhub/data_storage/database
+  value: {{ .Values.features.external_database.databases.credhub.name | quote }}
+- type: replace
+  path: /instance_groups/name=credhub/jobs/name=credhub/properties/credhub/data_storage/host
+  value: {{ .Values.features.external_database.host | quote }}
+- type: replace
+  path: /instance_groups/name=credhub/jobs/name=credhub/properties/credhub/data_storage/password
+  value: {{ .Values.features.external_database.databases.credhub.password | quote }}
+- type: replace
+  path: /instance_groups/name=credhub/jobs/name=credhub/properties/credhub/data_storage/username
+  value: {{ .Values.features.external_database.databases.credhub.username | quote }}
+- type: remove
+  path: /instance_groups/name=credhub/jobs/name=credhub/properties/credhub/data_storage/tls_ca?
+- type: replace
+  path: /instance_groups/name=credhub/jobs/name=credhub/properties/credhub/data_storage/require_tls?
+  value: false
+
+{{- else -}}
+
+# Override the addresses for the jobs under the scheduler instance group.
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/ccdb/address?
+  value: sql-db.service.cf.internal
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/ccdb/address
+  value: sql-db.service.cf.internal
+
 # Remove the PXC release and related variables.
 - type: remove
   path: /releases/name=pxc
@@ -141,4 +461,6 @@
 {{- $root := . -}}
 {{- range $path, $bytes := .Files.Glob "assets/operations/pre_render_scripts/database_*" }}
 {{ $root.Files.Get $path }}
+{{- end }}
+
 {{- end }}

--- a/deploy/helm/kubecf/assets/operations/instance_groups/scheduler.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/scheduler.yaml
@@ -1,11 +1,3 @@
-# Override the addresses for the jobs under the scheduler instance group.
-- type: replace
-  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/ccdb/address?
-  value: sql-db.service.cf.internal
-- type: replace
-  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/ccdb/address
-  value: sql-db.service.cf.internal
-
 # Add quarks properties for the scheduler job.
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=scheduler/properties/quarks?/run/healthcheck/scheduler

--- a/deploy/helm/kubecf/templates/single_availability.yaml
+++ b/deploy/helm/kubecf/templates/single_availability.yaml
@@ -20,9 +20,6 @@ data:
       path: /instance_groups/name=adapter/instances
       value: 1
     - type: replace
-      path: /instance_groups/name=database/instances
-      value: 1
-    - type: replace
       path: /instance_groups/name=diego-api/instances
       value: 1
     - type: replace
@@ -57,8 +54,6 @@ data:
     - type: remove
       path: /instance_groups/name=adapter/azs?
     - type: remove
-      path: /instance_groups/name=database/azs?
-    - type: remove
       path: /instance_groups/name=diego-api/azs?
     - type: remove
       path: /instance_groups/name=uaa/azs?
@@ -91,6 +86,14 @@ data:
       value: 1
     - type: remove
       path: /instance_groups/name=eirini/azs?
+    {{- end }}
+
+    {{- if not .Values.features.external_database.enabled }}
+    - type: replace
+      path: /instance_groups/name=database/instances
+      value: 1
+    - type: remove
+      path: /instance_groups/name=database/azs?
     {{- end }}
 
 {{- end }}

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -60,6 +60,48 @@ features:
   # published to docker.io.
   suse_buildpacks: false
 
+  # external_database disables the embedded database and allows using an external, already seeded,
+  # database.
+  # The database type can be either 'mysql' or 'postgres'.
+  external_database:
+    enabled: false
+    type: ~
+    host: ~
+    port: ~
+    databases:
+      uaa:
+        name: uaa
+        password: ~
+        username: ~
+      cc:
+        name: cloud_controller
+        password: ~
+        username: ~
+      bbs:
+        name: diego
+        password: ~
+        username: ~
+      routing_api:
+        name: routing-api
+        password: ~
+        username: ~
+      policy_server:
+        name: network_policy
+        password: ~
+        username: ~
+      silk_controller:
+        name: network_connectivity
+        password: ~
+        username: ~
+      locket:
+        name: locket
+        password: ~
+        username: ~
+      credhub:
+        name: credhub
+        password: ~
+        username: ~
+
 operations:
   # A list of configmap names that should be applied to the BOSH manifest.
   custom: []

--- a/dev/external_database/BUILD.bazel
+++ b/dev/external_database/BUILD.bazel
@@ -1,0 +1,11 @@
+package(default_visibility = ["//visibility:public"])
+
+load(":def.bzl", "deploy_mysql")
+
+exports_files([
+    "deploy_mysql.sh",
+])
+
+deploy_mysql(
+    name = "deploy_mysql",
+)

--- a/dev/external_database/def.bzl
+++ b/dev/external_database/def.bzl
@@ -1,0 +1,54 @@
+load("@bazel_skylib//lib:paths.bzl", "paths")
+
+def _deploy_mysql_impl(ctx):
+    template_name = paths.basename(ctx.file._script_template.short_path)
+    script = ctx.actions.declare_file("rendered_{}".format(template_name))
+
+    ctx.actions.expand_template(
+        template = ctx.file._script_template,
+        output = script,
+        substitutions = {
+            "{MYSQL_CHART}": ctx.file._mysql_chart.path,
+            "{HELM}": ctx.executable._helm.path,
+            "{KUBECTL}": ctx.executable._kubectl.path,
+        },
+        is_executable = True,
+    )
+
+    runfiles = [
+        ctx.file._mysql_chart,
+        ctx.executable._helm,
+        ctx.executable._kubectl,
+    ]
+    return [DefaultInfo(
+        executable = script,
+        runfiles = ctx.runfiles(files = runfiles),
+    )]
+
+deploy_mysql = rule(
+    implementation = _deploy_mysql_impl,
+    attrs = {
+        "_mysql_chart": attr.label(
+            allow_single_file = True,
+            default = "@mysql_chart//file",
+        ),
+        "_helm": attr.label(
+            allow_single_file = True,
+            cfg = "host",
+            default = "@helm//:helm",
+            executable = True,
+        ),
+        "_kubectl": attr.label(
+            allow_single_file = True,
+            cfg = "host",
+            default = "@kubectl//kubectl",
+            executable = True,
+        ),
+        "_script_template": attr.label(
+            allow_single_file = True,
+            cfg = "host",
+            default = "//dev/external_database:deploy_mysql.sh",
+        ),
+    },
+    executable = True,
+)

--- a/dev/external_database/deploy_mysql.sh
+++ b/dev/external_database/deploy_mysql.sh
@@ -2,6 +2,8 @@
 
 set -o errexit -o nounset -o pipefail
 
+MYSQL_CLIENT_IMAGE="mysql@sha256:c93ba1bafd65888947f5cd8bd45deb7b996885ec2a16c574c530c389335e9169"
+
 default_name="kubecf-mysql"
 printf "Name (%s): " "${default_name}"
 read -r name
@@ -56,12 +58,12 @@ fi
   --timeout 300s
 
 # Ensure the database is fully functional.
-until echo "SELECT 'Ready!'" | "{KUBECTL}" run mysql-client --rm -i --restart='Never' --image mysql --namespace "${namespace}" --command -- \
+until echo "SELECT 'Ready!'" | "{KUBECTL}" run mysql-client --rm -i --restart='Never' --image "${MYSQL_CLIENT_IMAGE}" --namespace "${namespace}" --command -- \
     mysql --host="${name}.${namespace}.svc" --user=root --password="${root_password}"; do
       sleep 1
 done
 
-"{KUBECTL}" run mysql-client --rm -i --restart='Never' --image mysql --namespace "${namespace}" --command -- \
+"{KUBECTL}" run mysql-client --rm -i --restart='Never' --image "${MYSQL_CLIENT_IMAGE}" --namespace "${namespace}" --command -- \
     mysql --host="${name}.${namespace}.svc" --user=root --password="${root_password}" \
     < <(
       for database in ${databases[*]}; do

--- a/dev/external_database/deploy_mysql.sh
+++ b/dev/external_database/deploy_mysql.sh
@@ -56,12 +56,12 @@ fi
   --timeout 300s
 
 # Ensure the database is fully functional.
-until echo "SELECT 'Ready!'" | "{KUBECTL}" run mysql-client --rm -i --restart='Never' --image docker.io/mysql --namespace "${namespace}" --command -- \
+until echo "SELECT 'Ready!'" | "{KUBECTL}" run mysql-client --rm -i --restart='Never' --image mysql --namespace "${namespace}" --command -- \
     mysql --host="${name}.${namespace}.svc" --user=root --password="${root_password}"; do
       sleep 1
 done
 
-"{KUBECTL}" run mysql-client --rm -i --restart='Never' --image docker.io/mysql --namespace "${namespace}" --command -- \
+"{KUBECTL}" run mysql-client --rm -i --restart='Never' --image mysql --namespace "${namespace}" --command -- \
     mysql --host="${name}.${namespace}.svc" --user=root --password="${root_password}" \
     < <(
       for database in ${databases[*]}; do

--- a/dev/external_database/deploy_mysql.sh
+++ b/dev/external_database/deploy_mysql.sh
@@ -57,9 +57,10 @@ until echo "SELECT 'Ready!'" | "{KUBECTL}" run mysql-client --rm -i --restart='N
       sleep 1
 done
 
-cat <(
-for database in ${databases[*]}; do
-  echo "CREATE DATABASE IF NOT EXISTS \`${database}\`;"
-done
-) | "{KUBECTL}" run mysql-client --rm -i --restart='Never' --image docker.io/mysql --namespace "${namespace}" --command -- \
-    mysql --host="${name}.${namespace}.svc" --user=root --password="${root_password}"
+"{KUBECTL}" run mysql-client --rm -i --restart='Never' --image docker.io/mysql --namespace "${namespace}" --command -- \
+    mysql --host="${name}.${namespace}.svc" --user=root --password="${root_password}" \
+    < <(
+      for database in ${databases[*]}; do
+        echo "CREATE DATABASE IF NOT EXISTS \`${database}\`;"
+      done
+    )

--- a/dev/external_database/deploy_mysql.sh
+++ b/dev/external_database/deploy_mysql.sh
@@ -49,7 +49,11 @@ fi
   | "{KUBECTL}" apply -f - \
     --namespace "${namespace}"
 
-"{KUBECTL}" wait --for condition=ready --namespace "${namespace}" pod --selector "app=${name}"
+"{KUBECTL}" wait pod \
+  --for condition=ready \
+  --namespace "${namespace}" \
+  --selector "app=${name}" \
+  --timeout 300s
 
 # Ensure the database is fully functional.
 until echo "SELECT 'Ready!'" | "{KUBECTL}" run mysql-client --rm -i --restart='Never' --image docker.io/mysql --namespace "${namespace}" --command -- \

--- a/dev/external_database/deploy_mysql.sh
+++ b/dev/external_database/deploy_mysql.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o pipefail
+
+default_name="kubecf-mysql"
+printf "Name (%s): " "${default_name}"
+read -r name
+if [ -z "${name}" ]; then
+  name="${default_name}"
+fi
+
+default_namespace="kubecf-mysql"
+printf "Namespace (%s): " "${default_namespace}"
+read -r namespace
+if [ -z "${namespace}" ]; then
+  namespace="${default_namespace}"
+fi
+
+stty -echo
+printf "Root password: "
+read -r root_password
+stty echo
+printf "\\n"
+if [ -z "${root_password}" ]; then
+  >&2 echo "The root password cannot be empty"
+  exit 1
+fi
+
+databases=(
+  "cloud_controller"
+  "diego"
+  "network_connectivity"
+  "network_policy"
+  "routing-api"
+  "uaa"
+  "locket"
+  "credhub"
+)
+
+if ! "{KUBECTL}" get namespace "${namespace}" 1> /dev/null 2> /dev/null; then
+  "{KUBECTL}" create namespace "${namespace}"
+fi
+
+"{HELM}" template "{MYSQL_CHART}" \
+  --name "${name}" \
+  --namespace "${namespace}" \
+  --set "mysqlRootPassword=${root_password}" \
+  --set "testFramework.enabled=false" \
+  | "{KUBECTL}" apply -f - \
+    --namespace "${namespace}"
+
+"{KUBECTL}" wait --for condition=ready --namespace "${namespace}" pod --selector "app=${name}"
+
+# Ensure the database is fully functional.
+until echo "SELECT 'Ready!'" | "{KUBECTL}" run mysql-client --rm -i --restart='Never' --image docker.io/mysql --namespace "${namespace}" --command -- \
+    mysql --host="${name}.${namespace}.svc" --user=root --password="${root_password}"; do
+      sleep 1
+done
+
+cat <(
+for database in ${databases[*]}; do
+  echo "CREATE DATABASE IF NOT EXISTS \`${database}\`;"
+done
+) | "{KUBECTL}" run mysql-client --rm -i --restart='Never' --image docker.io/mysql --namespace "${namespace}" --command -- \
+    mysql --host="${name}.${namespace}.svc" --user=root --password="${root_password}"

--- a/doc/dev/general.md
+++ b/doc/dev/general.md
@@ -151,3 +151,60 @@ cluster to the Ingress Controller service.
 
 Use the Helm option `--set features.ingress.enabled=true` when
 deploying kubecf.
+
+#### External Database
+
+By default, kubecf includes a single-availability database provided by the
+cf-mysql-release. Kubecf also exposes a way to use an external database via the
+Helm property `features.external_database`. Check the [values.yaml] for more
+details.
+
+[values.yaml]: ../../deploy/helm/kubecf/values.yaml
+
+For local development with an external database, the
+`bazel run //dev/external_database:deploy_mysql` command will bring a mysql database up and running
+ready to be consumed by kubecf.
+
+An example for the additional values to be provided to `//dev/kubecf:apply`:
+
+```yaml
+features:
+  external_database:
+    enabled: true
+    type: mysql
+    host: kubecf-mysql.kubecf-mysql.svc
+    port: 3306
+    databases:
+      uaa:
+        name: uaa
+        password: <root_password>
+        username: root
+      cc:
+        name: cloud_controller
+        password: <root_password>
+        username: root
+      bbs:
+        name: diego
+        password: <root_password>
+        username: root
+      routing_api:
+        name: routing-api
+        password: <root_password>
+        username: root
+      policy_server:
+        name: network_policy
+        password: <root_password>
+        username: root
+      silk_controller:
+        name: network_connectivity
+        password: <root_password>
+        username: root
+      locket:
+        name: locket
+        password: <root_password>
+        username: root
+      credhub:
+        name: credhub
+        password: <root_password>
+        username: root
+```


### PR DESCRIPTION
## Description

Adds the external database functionality via Helm values.

Resolves https://github.com/SUSE/kubecf/issues/4.

## Motivation and Context

Using an external database is desired on large setups and on setups that consume managed databases.

## How Has This Been Tested?

The local development and testing was conducted using the provided script for deploying a local mysql database on a separate namespace and deploying kubecf with the example values provided in the updated documentation. The kubecf deployment completed successfully and smoke-tests passed.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
