### PR TITLE
Fixed storage class when none is provided

### DIFF
--- a/deploy/helm/kubecf/assets/operations/instance_groups/database.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/database.yaml
@@ -23,6 +23,9 @@
 - type: replace
   path: /instance_groups/name=database/persistent_disk_type
   value: {{ .Values.kube.storage_class }}
+{{- else }}
+- type: remove
+  path: /instance_groups/name=database/persistent_disk_type
 {{- end }}
 
 # Replace the jobs using the cf-mysql-release.

--- a/deploy/helm/kubecf/assets/operations/instance_groups/singleton-blobstore.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/singleton-blobstore.yaml
@@ -5,6 +5,9 @@
 - type: replace
   path: /instance_groups/name=singleton-blobstore/persistent_disk_type
   value: {{ .Values.kube.storage_class }}
+{{- else }}
+- type: remove
+  path: /instance_groups/name=singleton-blobstore/persistent_disk_type
 {{- end }}
 
 - type: replace


### PR DESCRIPTION
When a storage class is not provided, we need to remove `/instance_groups/name=<ig>/persistent_disk_type`.