### PR TITLE
Bump CATS release to 0.0.6

### DIFF
--- a/deploy/helm/kubecf/assets/operations/instance_groups/acceptance-tests.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/acceptance-tests.yaml
@@ -2,8 +2,9 @@
   type: replace
   value:
     name: cf-acceptance-tests
-    url: {{ .Values.releases.defaults.url | quote }}
-    version: 0.0.5
+    url: {{ include "kubecf.releaseURLLookup" (list .Values.releases "cf-acceptance-tests") }}
+    version: 0.0.6
+    stemcell: {{ include "kubecf.stemcellLookup" (list .Values.releases "cf-acceptance-tests") }}
 
 - path: /instance_groups/-
   type: replace

--- a/deploy/helm/kubecf/assets/operations/instance_groups/database.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/database.yaml
@@ -12,10 +12,8 @@
   value:
     name: cf-mysql
     url: {{ .Values.releases.defaults.url | quote }}
-    version: {{ .Values.releases.database.version | quote }}
-    stemcell:
-      os: {{ .Values.releases.defaults.stemcell.os | quote }}
-      version: {{ .Values.releases.database.stemcell.version | quote }}
+    version: {{ index .Values.releases "cf-mysql" "version" | quote }}
+    stemcell: {{ include "kubecf.stemcellLookup" (list .Values.releases "cf-mysql") }}
 
 # Configure the persistent disk in the way that cf-operator can provision.
 - type: replace

--- a/deploy/helm/kubecf/assets/operations/set_release_versions.yaml
+++ b/deploy/helm/kubecf/assets/operations/set_release_versions.yaml
@@ -5,6 +5,4 @@
   value: {{ .Values.releases.capi.version | quote }}
 - type: replace
   path: /releases/name=capi/stemcell?
-  value:
-    os: {{ .Values.releases.defaults.stemcell.os | quote }}
-    version: {{ .Values.releases.capi.stemcell.version | quote }}
+  value: {{ include "kubecf.stemcellLookup" (list .Values.releases "capi") }}

--- a/deploy/helm/kubecf/templates/_helpers.tpl
+++ b/deploy/helm/kubecf/templates/_helpers.tpl
@@ -101,3 +101,18 @@ and possible overrides for the respective release.
 
   {{- toJson $result }}
 {{- end -}}
+
+{{/*
+Returns the release URL to use; if there is an override, use that, otherwise
+use the default.
+
+Usage:
+  - path: /releases/name=foo/url
+    type: replace
+    value: {{ include "kubecf.releaseURLLookup" (list .Values.releases "foo") }}
+*/}}
+{{- define "kubecf.releaseURLLookup" -}}
+  {{- $releasesMap := index . 0 -}}
+  {{- $releaseName := index . 1 }}
+  {{- (default (index $releasesMap "defaults" "url") (index (default (dict) (index $releasesMap $releaseName)) "url")) }}
+{{- end -}}

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -34,7 +34,7 @@ releases:
   cf-acceptance-tests:
     stemcell:
       version: 36.g03b4653-30.80-7.0.0_367.g6b06e343
-  database:
+  cf-mysql:
     version: 36.19.0
     stemcell:
       version: 36.g03b4653-30.80-7.0.0_360.g0ec8d681

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -31,6 +31,9 @@ releases:
     version: 1.83.0
     stemcell:
       version: 36.g03b4653-30.80-7.0.0_360.g0ec8d681
+  cf-acceptance-tests:
+    stemcell:
+      version: 36.g03b4653-30.80-7.0.0_367.g6b06e343
   database:
     version: 36.19.0
     stemcell:


### PR DESCRIPTION
## Description
Bump cf-acceptance-tests-release to 0.0.6.

## Motivation and Context
We broke running CATS in cf-acceptance-tests-release 0.0.5.

## How Has This Been Tested?
Deployed locally, and checked that CATS starts.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Additional information:
I've fixed the remaining releases that do _not_ use the `kubecf.stemcellLookup` template to now do so.