### PR TITLE
Fix ssh-proxy

### DIFF
--- a/.gitlab/pipelines/runtime/config.sh
+++ b/.gitlab/pipelines/runtime/config.sh
@@ -2,9 +2,9 @@
 
 export KUBECF_NAMESPACE="kubecf"
 export CF_OPERATOR_NAMESPACE="cfo"
-export ROUTER_CLUSTER_IP="10.43.0.250"
-export SSH_PROXY_CLUSTER_IP="10.43.0.251"
-export SYSTEM_DOMAIN="kubecf-ci.susecap.net"
+export ROUTER_CLUSTER_IP="10.43.0.231"
+export SSH_PROXY_CLUSTER_IP="10.43.0.232"
+export SYSTEM_DOMAIN="k3s-ci.kubecf.aws.howdoi.website"
 : "${EIRINI_ENABLED:=false}"
 export EIRINI_ENABLED
 export KUBECF_CHART_TARGET="//deploy/helm/kubecf:chart"

--- a/.gitlab/pipelines/runtime/config.sh
+++ b/.gitlab/pipelines/runtime/config.sh
@@ -2,8 +2,9 @@
 
 export KUBECF_NAMESPACE="kubecf"
 export CF_OPERATOR_NAMESPACE="cfo"
-export CLUSTER_IP="10.43.0.255"
-export SYSTEM_DOMAIN="${CLUSTER_IP}.nip.io"
+export ROUTER_CLUSTER_IP="10.43.0.250"
+export SSH_PROXY_CLUSTER_IP="10.43.0.251"
+export SYSTEM_DOMAIN="kubecf-ci.susecap.net"
 : "${EIRINI_ENABLED:=false}"
 export EIRINI_ENABLED
 export KUBECF_CHART_TARGET="//deploy/helm/kubecf:chart"

--- a/.gitlab/pipelines/stages/deploy/deploy_kubecf.sh
+++ b/.gitlab/pipelines/stages/deploy/deploy_kubecf.sh
@@ -14,9 +14,13 @@ values="$(mktemp -t values_XXXXXXXX.yaml)"
 cat > "${values}" <<EOF
 system_domain: "${SYSTEM_DOMAIN}"
 
-service:
-  type: ClusterIP
-  clusterIP: "${CLUSTER_IP}"
+services:
+  router:
+    type: ClusterIP
+    clusterIP: ${ROUTER_CLUSTER_IP}
+  ssh-proxy:
+    type: ClusterIP
+    clusterIP: ${SSH_PROXY_CLUSTER_IP}
 
 features:
   eirini:

--- a/deploy/helm/kubecf/assets/operations/instance_groups/router.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/router.yaml
@@ -6,7 +6,6 @@
     - name: router
       protocol: TCP
       internal: 8000
-      public: true
     - name: router-ssl
       protocol: TCP
       internal: 443

--- a/deploy/helm/kubecf/assets/operations/instance_groups/scheduler.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/scheduler.yaml
@@ -78,6 +78,18 @@
             httpGet:
               port: 2223
 
+# Add necessary labels to the scheduler instance group so that the service can select it to create
+# the endpoint.
+- type: replace
+  path: /instance_groups/name=scheduler/env?/bosh/agent/settings/labels/app.kubernetes.io~1component
+  value: "ssh-proxy"
+- type: replace
+  path: /instance_groups/name=scheduler/env?/bosh/agent/settings/labels/app.kubernetes.io~1instance
+  value: {{ .Release.Name | quote }}
+- type: replace
+  path: /instance_groups/name=scheduler/env?/bosh/agent/settings/labels/app.kubernetes.io~1version
+  value: {{ default .Chart.Version .Chart.AppVersion | quote }}
+
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=log-cache-scheduler/properties?/quarks/run/healthcheck/log-cache-scheduler/readiness/exec/command
   value: [curl, --fail, --silent, http://localhost:6064/debug/pprof/cmdline]

--- a/deploy/helm/kubecf/templates/ingress.yaml
+++ b/deploy/helm/kubecf/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- $root := . -}}
 {{- if .Values.features.ingress.enabled -}}
 {{- if and .Values.features.ingress.tls.crt .Values.features.ingress.tls.key -}}
 ---
@@ -98,15 +99,15 @@ spec:
               serviceName: "{{ .Values.deployment_name }}-router"
               servicePort: 443
 {{- else }}
-{{- $root := . -}}
-{{- range $name, $service := .Values.services }}
 ---
+{{- with $service := index .Values.services "router" }}
+{{ $_ := set $service "name" "router" }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ $root.Values.deployment_name }}-{{ $name }}-public"
+  name: "{{ $root.Values.deployment_name }}-{{ $service.name }}-public"
   labels:
-    app.kubernetes.io/component: {{ $name | quote }}
+    app.kubernetes.io/component: {{ $service.name | quote }}
     app.kubernetes.io/instance: {{ $root.Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ $root.Release.Service | quote }}
     app.kubernetes.io/name: {{ default $root.Chart.Name $root.Values.nameOverride | trunc 63 | trimSuffix "-" | quote }}
@@ -114,10 +115,50 @@ metadata:
     helm.sh/chart: {{ printf "%s-%s" $root.Chart.Name ($root.Chart.Version | replace "+" "_") | quote }}
 spec:
   selector:
-    app.kubernetes.io/component: {{ $name | quote }}
+    app.kubernetes.io/component: {{ $service.name | quote }}
     app.kubernetes.io/instance: {{ $root.Release.Name | quote }}
     app.kubernetes.io/version: {{ default $root.Chart.Version $root.Chart.AppVersion | quote }}
-  ports: {{ $service.ports | toJson }}
+  ports:
+  - name: http
+    protocol: TCP
+    port: 80
+    targetPort: 8000
+  - name: https
+    protocol: TCP
+    port: 443
+    targetPort: 443
+  type: {{ $service.type | quote }}
+  {{- if gt (len $service.externalIPs) 0 }}
+  externalIPs: {{ $service.externalIPs | toJson }}
+  {{- end }}
+  {{- if $service.clusterIP }}
+  clusterIP: {{ $service.clusterIP | quote }}
+  {{- end }}
+{{- end }}
+---
+{{- with $service := index .Values.services "ssh-proxy" }}
+{{ $_ := set $service "name" "ssh-proxy" }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ $root.Values.deployment_name }}-{{ $service.name }}-public"
+  labels:
+    app.kubernetes.io/component: {{ $service.name | quote }}
+    app.kubernetes.io/instance: {{ $root.Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ $root.Release.Service | quote }}
+    app.kubernetes.io/name: {{ default $root.Chart.Name $root.Values.nameOverride | trunc 63 | trimSuffix "-" | quote }}
+    app.kubernetes.io/version: {{ default $root.Chart.Version $root.Chart.AppVersion | quote }}
+    helm.sh/chart: {{ printf "%s-%s" $root.Chart.Name ($root.Chart.Version | replace "+" "_") | quote }}
+spec:
+  selector:
+    app.kubernetes.io/component: {{ $service.name | quote }}
+    app.kubernetes.io/instance: {{ $root.Release.Name | quote }}
+    app.kubernetes.io/version: {{ default $root.Chart.Version $root.Chart.AppVersion | quote }}
+  ports:
+  - name: ssh
+    protocol: TCP
+    port: 2222
+    targetPort: 2222
   type: {{ $service.type | quote }}
   {{- if gt (len $service.externalIPs) 0 }}
   externalIPs: {{ $service.externalIPs | toJson }}

--- a/deploy/helm/kubecf/templates/ingress.yaml
+++ b/deploy/helm/kubecf/templates/ingress.yaml
@@ -98,37 +98,32 @@ spec:
               serviceName: "{{ .Values.deployment_name }}-router"
               servicePort: 443
 {{- else }}
+{{- $root := . -}}
+{{- range $name, $service := .Values.services }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ .Values.deployment_name }}-router-public"
+  name: "{{ $root.Values.deployment_name }}-{{ $name }}-public"
   labels:
-    app.kubernetes.io/component: "router"
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/name: {{ default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" | quote }}
-    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
-    helm.sh/chart: {{ printf "%s-%s" .Chart.Name (.Chart.Version | replace "+" "_") | quote }}
+    app.kubernetes.io/component: {{ $name | quote }}
+    app.kubernetes.io/instance: {{ $root.Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ $root.Release.Service | quote }}
+    app.kubernetes.io/name: {{ default $root.Chart.Name $root.Values.nameOverride | trunc 63 | trimSuffix "-" | quote }}
+    app.kubernetes.io/version: {{ default $root.Chart.Version $root.Chart.AppVersion | quote }}
+    helm.sh/chart: {{ printf "%s-%s" $root.Chart.Name ($root.Chart.Version | replace "+" "_") | quote }}
 spec:
   selector:
-    app.kubernetes.io/component: "router"
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
-  ports:
-    - name: http
-      protocol: TCP
-      port: 80
-      targetPort: 8000
-    - name: https
-      protocol: TCP
-      port: 443
-      targetPort: 443
-  type: {{ .Values.service.type | quote }}
-  {{- if gt (len .Values.service.externalIPs) 0 }}
-  externalIPs: {{ .Values.service.externalIPs | toJson }}
+    app.kubernetes.io/component: {{ $name | quote }}
+    app.kubernetes.io/instance: {{ $root.Release.Name | quote }}
+    app.kubernetes.io/version: {{ default $root.Chart.Version $root.Chart.AppVersion | quote }}
+  ports: {{ $service.ports | toJson }}
+  type: {{ $service.type | quote }}
+  {{- if gt (len $service.externalIPs) 0 }}
+  externalIPs: {{ $service.externalIPs | toJson }}
   {{- end }}
-  {{- if .Values.service.clusterIP }}
-  clusterIP: {{ .Values.service.clusterIP | quote }}
+  {{- if $service.clusterIP }}
+  clusterIP: {{ $service.clusterIP | quote }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/deploy/helm/kubecf/templates/ingress.yaml
+++ b/deploy/helm/kubecf/templates/ingress.yaml
@@ -100,14 +100,13 @@ spec:
               servicePort: 443
 {{- else }}
 ---
-{{- with $service := index .Values.services "router" }}
-{{ $_ := set $service "name" "router" }}
+{{- with $service := .Values.services.router }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ $root.Values.deployment_name }}-{{ $service.name }}-public"
+  name: "{{ $root.Values.deployment_name }}-router-public"
   labels:
-    app.kubernetes.io/component: {{ $service.name | quote }}
+    app.kubernetes.io/component: router
     app.kubernetes.io/instance: {{ $root.Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ $root.Release.Service | quote }}
     app.kubernetes.io/name: {{ default $root.Chart.Name $root.Values.nameOverride | trunc 63 | trimSuffix "-" | quote }}
@@ -115,7 +114,7 @@ metadata:
     helm.sh/chart: {{ printf "%s-%s" $root.Chart.Name ($root.Chart.Version | replace "+" "_") | quote }}
 spec:
   selector:
-    app.kubernetes.io/component: {{ $service.name | quote }}
+    app.kubernetes.io/component: router
     app.kubernetes.io/instance: {{ $root.Release.Name | quote }}
     app.kubernetes.io/version: {{ default $root.Chart.Version $root.Chart.AppVersion | quote }}
   ports:
@@ -137,13 +136,12 @@ spec:
 {{- end }}
 ---
 {{- with $service := index .Values.services "ssh-proxy" }}
-{{ $_ := set $service "name" "ssh-proxy" }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ $root.Values.deployment_name }}-{{ $service.name }}-public"
+  name: "{{ $root.Values.deployment_name }}-ssh-proxy-public"
   labels:
-    app.kubernetes.io/component: {{ $service.name | quote }}
+    app.kubernetes.io/component: ssh-proxy
     app.kubernetes.io/instance: {{ $root.Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ $root.Release.Service | quote }}
     app.kubernetes.io/name: {{ default $root.Chart.Name $root.Values.nameOverride | trunc 63 | trimSuffix "-" | quote }}
@@ -151,7 +149,7 @@ metadata:
     helm.sh/chart: {{ printf "%s-%s" $root.Chart.Name ($root.Chart.Version | replace "+" "_") | quote }}
 spec:
   selector:
-    app.kubernetes.io/component: {{ $service.name | quote }}
+    app.kubernetes.io/component: ssh-proxy
     app.kubernetes.io/instance: {{ $root.Release.Name | quote }}
     app.kubernetes.io/version: {{ default $root.Chart.Version $root.Chart.AppVersion | quote }}
   ports:

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -45,12 +45,31 @@ releases:
 sizing:
   HA: false
 
-# Service is only valid to set an external endpoint for the router if features.ingress.enabled is
-# false.
-service:
-  type: LoadBalancer
-  externalIPs: []
-  clusterIP: ~
+# Service is only valid to set a external endpoints for the instance groups if
+# features.ingress.enabled is false.
+services:
+  router:
+    type: LoadBalancer
+    externalIPs: []
+    clusterIP: ~
+    ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 8000
+    - name: https
+      protocol: TCP
+      port: 443
+      targetPort: 443
+  ssh-proxy:
+    type: LoadBalancer
+    externalIPs: []
+    clusterIP: ~
+    ports:
+    - name: ssh
+      protocol: TCP
+      port: 2222
+      targetPort: 2222
 
 features:
   eirini:

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -52,24 +52,10 @@ services:
     type: LoadBalancer
     externalIPs: []
     clusterIP: ~
-    ports:
-    - name: http
-      protocol: TCP
-      port: 80
-      targetPort: 8000
-    - name: https
-      protocol: TCP
-      port: 443
-      targetPort: 443
   ssh-proxy:
     type: LoadBalancer
     externalIPs: []
     clusterIP: ~
-    ports:
-    - name: ssh
-      protocol: TCP
-      port: 2222
-      targetPort: 2222
 
 features:
   eirini:

--- a/doc/dev/general.md
+++ b/doc/dev/general.md
@@ -155,7 +155,8 @@ This has to happen before deploying kubecf.
 helm install stable/nginx-ingress \
   --name ingress \
   --namespace ingress \
-  --set "controller.service.externalIPs={$(minikube ip)}"
+  --set "controller.service.externalIPs={$(minikube ip)}" \
+  --set "tcp.2222=kubecf/kubecf-scheduler:2222"
 ```
 
 The last option in the command above assigns the external IP of the

--- a/doc/dev/general.md
+++ b/doc/dev/general.md
@@ -158,8 +158,7 @@ helm install stable/nginx-ingress \
   --set "tcp.2222=kubecf/kubecf-scheduler:2222"
 ```
 
-The last option in the command above assigns the external IP of the
-cluster to the Ingress Controller service.
+The `tcp.<port>` option uses the NGINX TCP pass-through.
 
 ##### Configure kubecf
 

--- a/doc/dev/general.md
+++ b/doc/dev/general.md
@@ -114,7 +114,7 @@ To access the cluster after the cf-operator has completed the
 deployment and all pods are active invoke:
 
 ```sh
-cf api --skip-ssl-validation "https://api.$(minikube ip).xip.io"
+cf api --skip-ssl-validation "https://api.<domain>"
 
 # Copy the admin cluster password.
 admin_pass=$(kubectl get secret \
@@ -155,7 +155,6 @@ This has to happen before deploying kubecf.
 helm install stable/nginx-ingress \
   --name ingress \
   --namespace ingress \
-  --set "controller.service.externalIPs={$(minikube ip)}" \
   --set "tcp.2222=kubecf/kubecf-scheduler:2222"
 ```
 

--- a/doc/dev/minikube.md
+++ b/doc/dev/minikube.md
@@ -143,9 +143,11 @@ This has to happen before deploying kubecf.
 helm install stable/nginx-ingress \
   --name ingress \
   --namespace ingress
-  --set "controller.service.externalIPs={$(minikube ip)}" \
-  --set "tcp.2222=kubecf/kubecf-scheduler:2222"
+  --set "tcp.2222=kubecf/kubecf-scheduler:2222" \
+  --set "controller.service.externalIPs={$(minikube ip)}"
 ```
+
+The `tcp.<port>` option uses the NGINX TCP pass-through.
 
 The last flag in the command above assigns the external IP of the
 cluster to the Ingress Controller service.

--- a/doc/dev/minikube.md
+++ b/doc/dev/minikube.md
@@ -143,7 +143,8 @@ This has to happen before deploying kubecf.
 helm install stable/nginx-ingress \
   --name ingress \
   --namespace ingress
-  --set "controller.service.externalIPs={$(minikube ip)}"
+  --set "controller.service.externalIPs={$(minikube ip)}" \
+  --set "tcp.2222=kubecf/kubecf-scheduler:2222"
 ```
 
 The last flag in the command above assigns the external IP of the


### PR DESCRIPTION
## Description

Fixes the ssh-proxy by exposing it via another service similar to the existing router one.

Fixes #146.

## Motivation and Context

The CATS `ssh` suite was failing, pointing out that we were missing its functionality.

## How Has This Been Tested?

Deployed kubecf with the following values:

```
system_domain: kubecf-dev.susecap.net

services:
  router:
    type: ClusterIP
    clusterIP: 10.104.255.1
  ssh-proxy:
    type: ClusterIP
    clusterIP: 10.104.255.2
```

Then ran CATS with only `ssh` suite enabled:

```
properties:
  acceptance-tests:
    acceptance-tests:
      acceptance_tests:
        include: '=ssh'
```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

## Breaking changes:

- The `service` property on the Helm chart was replaced by `services`, which now allows `router` and `ssh-proxy` to be set.
