### PR TITLE
Fix TYPO in dev docs for Cloud Foundry access

### DIFF
--- a/doc/dev/general.md
+++ b/doc/dev/general.md
@@ -104,12 +104,12 @@ cf api --skip-ssl-validation "https://api.$(minikube ip).xip.io"
 
 # Copy the admin cluster password.
 admin_pass=$(kubectl get secret \
-	      --namespace kubecf kubecf.var-cf-admin-password \
-	      -o jsonpath='{.data.password}' \
-	      | base64 --decode)
+        --namespace kubecf kubecf.var-cf-admin-password \
+        -o jsonpath='{.data.password}' \
+        | base64 --decode)
 
 # Use the password from the previous step when requested.
-cf auth -u admin -p "${admin_pass}"
+cf auth admin "${admin_pass}"
 ```
 
 ### Advanced Topics

--- a/doc/dev/minikube.md
+++ b/doc/dev/minikube.md
@@ -98,12 +98,12 @@ cf api --skip-ssl-validation "https://api.$(minikube ip).xip.io"
 
 # Copy the admin cluster password.
 acp=$(kubectl get secret \
-	      --namespace kubecf kubecf.var-cf-admin-password \
-	      -o jsonpath='{.data.password}' \
-	      | base64 --decode)
+        --namespace kubecf kubecf.var-cf-admin-password \
+        -o jsonpath='{.data.password}' \
+        | base64 --decode)
 
 # Use the password from the previous step when requested.
-cf auth -u admin -p "${acp}"
+cf auth admin "${acp}"
 ```
 
 ### Advanced Topics


### PR DESCRIPTION
## Description
The documentation for using the Cloud Foundry CLI to access the
development cluster contains a copy&paste TYPO.

## Motivation and Context
Remove the `-u` and `-p` flags that do not exist in `cf auth …`, but
that exist in `cf login …`.

## How Has This Been Tested?
Followed the development documentation steps to setup a `minikube` based Cloud Foundry.

## Screenshots (if appropriate):
```
cf auth --help
NAME:
   auth - Authenticate non-interactively

USAGE:
   cf auth USERNAME PASSWORD
   cf auth USERNAME PASSWORD --origin ORIGIN
   cf auth CLIENT_ID CLIENT_SECRET --client-credentials

ENVIRONMENT VARIABLES:
   CF_USERNAME=user          Authenticating user. Overridden if USERNAME argument is provided.
   CF_PASSWORD=password      Password associated with user. Overriden if PASSWORD argument is provided.

WARNING:
   Providing your password as a command line option is highly discouraged
   Your password may be visible to others and may be recorded in your shell history
   Consider using the CF_PASSWORD environment variable instead

EXAMPLES:
   cf auth name@example.com "my password" (use quotes for passwords with a space)
   cf auth name@example.com "\"password\"" (escape quotes if used in password)

OPTIONS:
   --client-credentials      Use (non-user) service account (also called client credentials)
   --origin                  Indicates the identity provider to be used for authentication

SEE ALSO:
   api, login, target
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
