### PR TITLE
Fixed routing-api IP that is used to register itself

### DIFF
--- a/bosh/releases/pre_render_scripts/api/routing-api/bpm/patch_bpm.sh
+++ b/bosh/releases/pre_render_scripts/api/routing-api/bpm/patch_bpm.sh
@@ -5,15 +5,18 @@ set -o errexit -o nounset
 target="/var/vcap/all-releases/jobs-src/routing/routing-api/templates/bpm.yml.erb"
 
 PATCH=$(cat <<'EOT'
-@@ -11,7 +11,7 @@
+@@ -11,8 +11,10 @@
      - -timeFormat
      - rfc3339
      - -ip
 -    - <%= spec.ip %>
-+    - 0.0.0.0
++    - "$(POD_IP)"
      <% if p("routing_api.auth_disabled") == true %>- -devMode <% end %>
++    env:
++      POD_IP: 0.0.0.0 # Set by k8s using an ops-file with cf-operator.
 
      hooks:
+       pre_start: /var/vcap/jobs/routing-api/bin/bpm-pre-start
 EOT
 )
 

--- a/deploy/helm/kubecf/assets/operations/instance_groups/api.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/api.yaml
@@ -155,6 +155,12 @@
 - type: replace
   path: /instance_groups/name=api/jobs/name=routing-api/properties/quarks?
   value:
+    envs:
+    - name: POD_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.podIP
     ports:
     - name: routing-api
       protocol: TCP


### PR DESCRIPTION
## Description

Fixes the `routing-api` IP that is used to register itself to provide `api.((system_domain))/routing`.

## Motivation and Context

The `routing-api` job registers itself via code, and it uses the `-ip` command-line flag for the destination IP. This patch will use the `POD_IP` environment variable that we set via the ops-file, and k8s will render it via https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#use-environment-variables-to-define-arguments.

## How Has This Been Tested?

Got a bash session to the router container and called `/var/vcap/jobs/gorouter/bin/retrieve-local-routes` and checked that the `address` for the `api.((system_domain))/routing` was set to the pod IP. Also, the command `cf router-groups` should succeed (previously failed). The CATS `tcp_routing` suite will eventually test this.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
