### PR TITLE
Eirini service account with namespaced role

### DIFF
--- a/.gitlab/pipelines/stages/deploy/deploy_kubecf.sh
+++ b/.gitlab/pipelines/stages/deploy/deploy_kubecf.sh
@@ -31,4 +31,4 @@ EOF
 chart="$(output_chart)"
 
 # Render and apply the kubecf chart.
-bazel run @helm//:helm -- template "${chart}" --name kubecf --namespace "${KUBECF_NAMESPACE}" --values "${values}" | "${KUBECTL}" apply -f - --namespace "${KUBECF_NAMESPACE}"
+bazel run @helm//:helm -- template "${chart}" --name kubecf --namespace "${KUBECF_NAMESPACE}" --values "${values}" | "${KUBECTL}" apply -f -

--- a/deploy/helm/kubecf/templates/azs.yaml
+++ b/deploy/helm/kubecf/templates/azs.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: ops-azs
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/component: operations
     app.kubernetes.io/instance: {{ .Release.Name | quote }}

--- a/deploy/helm/kubecf/templates/bosh_deployment.yaml
+++ b/deploy/helm/kubecf/templates/bosh_deployment.yaml
@@ -4,6 +4,7 @@ apiVersion: quarks.cloudfoundry.org/v1alpha1
 kind: BOSHDeployment
 metadata:
   name: {{ .Values.deployment_name }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}

--- a/deploy/helm/kubecf/templates/cf_deployment.yaml
+++ b/deploy/helm/kubecf/templates/cf_deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: cf-deployment
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}

--- a/deploy/helm/kubecf/templates/eirini.yaml
+++ b/deploy/helm/kubecf/templates/eirini.yaml
@@ -43,23 +43,31 @@ kind: Namespace
 metadata:
   name: {{ .Values.deployment_name }}-eirini
 ---
-# A godlike ServiceAccount for Eirini
-# TODO: this can be restricted
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.deployment_name }}-eirini
   namespace: {{ .Release.Namespace | quote }}
 ---
-# A godlike Role for Eirini
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: Role
 metadata:
-  name: {{ .Values.deployment_name }}-eirini
+  name: eirini:all
+  namespace: {{ .Values.deployment_name }}-eirini
+rules:
+  - apiGroups: ['*']
+    resources: ['*']
+    verbs:     ['*']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: eirini:all
+  namespace: {{ .Values.deployment_name }}-eirini
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
+  kind: Role
+  name: eirini:all
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.deployment_name }}-eirini

--- a/deploy/helm/kubecf/templates/eirini.yaml
+++ b/deploy/helm/kubecf/templates/eirini.yaml
@@ -6,6 +6,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.deployment_name }}-cc-uploader
+  namespace: {{ .Release.Namespace | quote }}
 spec:
   type: ClusterIP
   selector:
@@ -26,6 +27,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.deployment_name }}-eirini-registry
+  namespace: {{ .Release.Namespace | quote }}
 spec:
   type: NodePort
   selector:
@@ -77,6 +79,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: ops-remove-diego
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/component: operations
     app.kubernetes.io/instance: {{ .Release.Name | quote }}

--- a/deploy/helm/kubecf/templates/implicit_vars.yaml
+++ b/deploy/helm/kubecf/templates/implicit_vars.yaml
@@ -12,6 +12,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.deployment_name }}.var-{{ $variable_name | replace "_" "-" | replace "." "-" }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}

--- a/deploy/helm/kubecf/templates/ingress.yaml
+++ b/deploy/helm/kubecf/templates/ingress.yaml
@@ -105,6 +105,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: "{{ $root.Values.deployment_name }}-router-public"
+  namespace: {{ $root.Release.Namespace | quote }}
   labels:
     app.kubernetes.io/component: router
     app.kubernetes.io/instance: {{ $root.Release.Name | quote }}
@@ -140,6 +141,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: "{{ $root.Values.deployment_name }}-ssh-proxy-public"
+  namespace: {{ $root.Release.Namespace | quote }}
   labels:
     app.kubernetes.io/component: ssh-proxy
     app.kubernetes.io/instance: {{ $root.Release.Name | quote }}

--- a/deploy/helm/kubecf/templates/ops-use-bits-service.yaml
+++ b/deploy/helm/kubecf/templates/ops-use-bits-service.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: ops-use-bits-service
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}

--- a/deploy/helm/kubecf/templates/ops.yaml
+++ b/deploy/helm/kubecf/templates/ops.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "kubecf.ops-name" .Path }}
+  namespace: {{ .Root.Release.Namespace | quote }}
   labels:
     app.kubernetes.io/component: operations
     app.kubernetes.io/instance: {{ .Root.Release.Name | quote }}

--- a/deploy/helm/kubecf/templates/properties.yaml
+++ b/deploy/helm/kubecf/templates/properties.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: user-provided-properties
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/component: operations
     app.kubernetes.io/instance: {{ .Release.Name | quote }}

--- a/deploy/helm/kubecf/templates/sizing.yaml
+++ b/deploy/helm/kubecf/templates/sizing.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: ops-sizing
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/component: operations
     app.kubernetes.io/instance: {{ .Release.Name | quote }}

--- a/dev/kubecf/BUILD.bazel
+++ b/dev/kubecf/BUILD.bazel
@@ -15,11 +15,9 @@ helm_template(
 kubectl_apply_binary(
     name = "apply",
     resource = ":rendered_template",
-    namespace = project.namespace,
 )
 
 kubectl_delete_binary(
     name = "delete",
     resource = ":rendered_template",
-    namespace = project.namespace,
 )


### PR DESCRIPTION
## Description

Fixes the cluster-admin role for Eirini. It's now only able to perform operations on the app namespace.

Fixes https://github.com/SUSE/kubecf/issues/175.

## Motivation and Context

Eirini should not be a cluster-admin.

## How Has This Been Tested?

Deployed with Eirini and ran smoke-tests.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
