### PR TITLE
Remove .Values.deployment_name, use helm release name

### DIFF
--- a/def.bzl
+++ b/def.bzl
@@ -1,4 +1,5 @@
 project = struct(
+    deployment_name = "kubecf",
     namespace = "kubecf",
     cf_deployment = struct(
         version = "8.0.0",

--- a/deploy/helm/kubecf/assets/operations/instance_groups/bits.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/bits.yaml
@@ -24,7 +24,7 @@
 - type: replace
   path: /variables/name=bits_service_ssl/options/serviceRef?/-
   value:
-    name: {{ .Values.deployment_name }}-eirini-registry
+    name: {{ .Release.Name }}-eirini-registry
     namespace: {{ .Release.Namespace }}
 - type: replace
   path: /variables/name=bits_service_ssl/options/signer_type?
@@ -36,7 +36,7 @@
 # TODO: check to see where these should actually be public - what are the usecases?
 - type: replace
   path: /instance_groups/name=bits/jobs/name=bits-service/properties/bits-service?/public_endpoint
-  value: https://{{ .Values.deployment_name }}-bits.{{ .Release.Namespace }}
+  value: https://{{ .Release.Name }}-bits.{{ .Release.Namespace }}
 
 # Enable Docker registry on bits-service (used by OPI)
 - type: replace

--- a/deploy/helm/kubecf/assets/operations/instance_groups/doppler.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/doppler.yaml
@@ -71,7 +71,7 @@
   path: /instance_groups/name=doppler/jobs/name=log-cache-expvar-forwarder/properties/quarks?/envs
   value:
   - name: INSTANCE_ADDR
-    value: {{ .Values.deployment_name }}-doppler:8080
+    value: {{ .Release.Name }}-doppler:8080
   - name: INSTANCE_ID
     valueFrom:
       fieldRef:

--- a/deploy/helm/kubecf/assets/operations/instance_groups/eirini.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/eirini.yaml
@@ -24,7 +24,7 @@
       bosh:
         agent:
           settings:
-            serviceAccountName: {{ .Values.deployment_name }}-eirini
+            serviceAccountName: {{ .Release.Name }}-eirini
             disable_log_sidecar: true
     jobs:
     - name: configure-eirini-scf
@@ -45,7 +45,7 @@
               server_key: "((cc_bridge_cc_uploader_server.private_key))"
         opi:
           registry_address: 127.0.0.1:{{ .Values.features.eirini.registry.service.nodePort }}
-          kube_namespace: {{ .Values.deployment_name }}-eirini
+          kube_namespace: {{ .Release.Name }}-eirini
           certs_secret_name: eirini-staging-secret
           cc_cert: ((cc_bridge_tps.certificate))
           cc_key: ((cc_bridge_tps.private_key))
@@ -69,7 +69,7 @@
       bosh:
         agent:
           settings:
-            serviceAccountName: {{ .Values.deployment_name }}-eirini
+            serviceAccountName: {{ .Release.Name }}-eirini
     jobs:
     - name: eirini-loggregator-bridge
       release: eirini
@@ -84,7 +84,7 @@
           loggregator_cert: '((loggregator_tls_agent.certificate))'
           loggregator_key: '((loggregator_tls_agent.private_key))'
           loggregator_endpoint: "doppler.service.cf.internal:8082"
-          namespace: '{{ .Values.deployment_name }}-eirini'
+          namespace: '{{ .Release.Name }}-eirini'
     - name: opi
       release: eirini
       properties:
@@ -92,7 +92,7 @@
           server_cert: ((eirini_tls_server_cert.certificate))
           server_key: ((eirini_tls_server_cert.private_key))
           client_ca: ((service_cf_internal_ca.certificate))
-          kube_namespace: {{ .Values.deployment_name }}-eirini
+          kube_namespace: {{ .Release.Name }}-eirini
           kube_service_host: ""
           kube_service_port: ""
           registry_address: 127.0.0.1:{{ .Values.features.eirini.registry.service.nodePort }}
@@ -102,7 +102,7 @@
           nats_ip: nats.service.cf.internal
           certs_secret_name: eirini-staging-secret
           cc_internal_api: https://cloud-controller-ng.service.cf.internal:9023
-          eirini_address: https://{{ .Values.deployment_name }}-eirini.{{ .Release.Namespace }}:8484
+          eirini_address: https://{{ .Release.Name }}-eirini.{{ .Release.Namespace }}:8484
           downloader_image: "eirini/recipe-downloader:0.3.0"
           uploader_image: "eirini/recipe-uploader:0.3.0"
           executor_image: "eirini/recipe-executor:0.3.0"
@@ -140,7 +140,7 @@
 # Set the correct addresses to be reached by the Eirini apps namespace.
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/buildpacks?/webdav_config/private_endpoint
-  value: &blobstore_url "https://{{ .Values.deployment_name }}-singleton-blobstore.{{ .Release.Namespace }}:4443"
+  value: &blobstore_url "https://{{ .Release.Name }}-singleton-blobstore.{{ .Release.Namespace }}:4443"
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/droplets?/webdav_config/private_endpoint
   value: *blobstore_url
@@ -152,16 +152,16 @@
   value: *blobstore_url
 - type: replace
   path: /variables/name=blobstore_tls/options/alternative_names?/-
-  value: "{{ .Values.deployment_name }}-singleton-blobstore"
+  value: "{{ .Release.Name }}-singleton-blobstore"
 - type: replace
   path: /variables/name=blobstore_tls/options/alternative_names?/-
-  value: "{{ .Values.deployment_name }}-singleton-blobstore.{{ .Release.Namespace }}"
+  value: "{{ .Release.Name }}-singleton-blobstore.{{ .Release.Namespace }}"
 - type: replace
   path: /instance_groups/name=api/jobs/name=cc_uploader/properties/internal_hostname?
-  value: "{{ .Values.deployment_name }}-api.{{ .Release.Namespace }}"
+  value: "{{ .Release.Name }}-api.{{ .Release.Namespace }}"
 - type: replace
   path: /variables/name=cc_bridge_cc_uploader_server/options/alternative_names?/-
-  value: "{{ .Values.deployment_name }}-api.{{ .Release.Namespace }}"
+  value: "{{ .Release.Name }}-api.{{ .Release.Namespace }}"
 
 # Enable OPI in CC
 # cloud_controller_ng
@@ -231,10 +231,10 @@
     type: certificate
     options:
       ca: service_cf_internal_ca
-      common_name: "{{ .Values.deployment_name }}-eirini"
+      common_name: "{{ .Release.Name }}-eirini"
       alternative_names:
-      - "{{ .Values.deployment_name }}-eirini"
-      - "{{ .Values.deployment_name }}-eirini.{{ .Release.Namespace }}"
+      - "{{ .Release.Name }}-eirini"
+      - "{{ .Release.Name }}-eirini.{{ .Release.Namespace }}"
       - eirini.service.cf.internal
       extended_key_usage:
       - server_auth

--- a/deploy/helm/kubecf/assets/operations/instance_groups/scheduler.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/scheduler.yaml
@@ -94,7 +94,7 @@
   path: /instance_groups/name=scheduler/jobs/name=log-cache-expvar-forwarder/properties/quarks?/envs
   value:
   - name: INSTANCE_ADDR
-    value: {{ .Values.deployment_name }}-scheduler:8080
+    value: {{ .Release.Name }}-scheduler:8080
   - name: INSTANCE_ID
     valueFrom:
       fieldRef:

--- a/deploy/helm/kubecf/assets/operations/set_deployment_name.yaml
+++ b/deploy/helm/kubecf/assets/operations/set_deployment_name.yaml
@@ -1,3 +1,3 @@
 - type: replace
   path: /name
-  value: {{ .Values.deployment_name | quote }}
+  value: {{ .Release.Name | quote }}

--- a/deploy/helm/kubecf/templates/bosh_deployment.yaml
+++ b/deploy/helm/kubecf/templates/bosh_deployment.yaml
@@ -3,7 +3,7 @@
 apiVersion: quarks.cloudfoundry.org/v1alpha1
 kind: BOSHDeployment
 metadata:
-  name: {{ .Values.deployment_name }}
+  name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/instance: {{ .Release.Name | quote }}

--- a/deploy/helm/kubecf/templates/eirini.yaml
+++ b/deploy/helm/kubecf/templates/eirini.yaml
@@ -5,13 +5,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.deployment_name }}-cc-uploader
+  name: {{ .Release.Name }}-cc-uploader
   namespace: {{ .Release.Namespace | quote }}
 spec:
   type: ClusterIP
   selector:
     quarks.cloudfoundry.org/instance-group-name: api
-    quarks.cloudfoundry.org/deployment-name: {{ .Values.deployment_name }}
+    quarks.cloudfoundry.org/deployment-name: {{ .Release.Name }}
   ports:
     - protocol: TCP
       name: "http"
@@ -26,13 +26,13 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.deployment_name }}-eirini-registry
+  name: {{ .Release.Name }}-eirini-registry
   namespace: {{ .Release.Namespace | quote }}
 spec:
   type: NodePort
   selector:
     quarks.cloudfoundry.org/instance-group-name: bits
-    quarks.cloudfoundry.org/deployment-name: {{ .Values.deployment_name }}
+    quarks.cloudfoundry.org/deployment-name: {{ .Release.Name }}
   ports:
     - protocol: TCP
       port: 443
@@ -43,19 +43,19 @@ spec:
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: {{ .Values.deployment_name }}-eirini
+  name: {{ .Release.Name }}-eirini
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.deployment_name }}-eirini
+  name: {{ .Release.Name }}-eirini
   namespace: {{ .Release.Namespace | quote }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: eirini:all
-  namespace: {{ .Values.deployment_name }}-eirini
+  namespace: {{ .Release.Name }}-eirini
 rules:
   - apiGroups: ['*']
     resources: ['*']
@@ -65,14 +65,14 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: eirini:all
-  namespace: {{ .Values.deployment_name }}-eirini
+  namespace: {{ .Release.Name }}-eirini
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: eirini:all
 subjects:
   - kind: ServiceAccount
-    name: {{ .Values.deployment_name }}-eirini
+    name: {{ .Release.Name }}-eirini
     namespace: {{ .Release.Namespace | quote }}
 ---
 apiVersion: v1

--- a/deploy/helm/kubecf/templates/implicit_vars.yaml
+++ b/deploy/helm/kubecf/templates/implicit_vars.yaml
@@ -11,7 +11,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.deployment_name }}.var-{{ $variable_name | replace "_" "-" | replace "." "-" }}
+  name: {{ .Release.Name }}.var-{{ $variable_name | replace "_" "-" | replace "." "-" }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/instance: {{ .Release.Name | quote }}

--- a/deploy/helm/kubecf/templates/ingress.yaml
+++ b/deploy/helm/kubecf/templates/ingress.yaml
@@ -53,7 +53,7 @@ metadata:
     {{- if not (hasKey .Values.features.ingress.annotations "nginx.ingress.kubernetes.io/proxy-body-size") -}}
       {{ $_ := set .Values.features.ingress.annotations "nginx.ingress.kubernetes.io/proxy-body-size" "8m" }}
     {{- end }}
-    {{ $_ := set .Values.features.ingress.annotations "nginx.org/websocket-services" (printf "%s-router" .Values.deployment_name) }}
+    {{ $_ := set .Values.features.ingress.annotations "nginx.org/websocket-services" (printf "%s-router" .Release.Name) }}
 {{ toYaml .Values.features.ingress.annotations | indent 4 }}
   labels:
     {{ if not (hasKey .Values.features.ingress.labels "app.kubernetes.io/component") }}
@@ -89,14 +89,14 @@ spec:
         paths:
           - path: "/"
             backend:
-              serviceName: "{{ .Values.deployment_name }}-router"
+              serviceName: "{{ .Release.Name }}-router"
               servicePort: 443
     - host: "{{ .Values.system_domain }}"
       http:
         paths:
           - path: "/"
             backend:
-              serviceName: "{{ .Values.deployment_name }}-router"
+              serviceName: "{{ .Release.Name }}-router"
               servicePort: 443
 {{- else }}
 ---
@@ -104,7 +104,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ $root.Values.deployment_name }}-router-public"
+  name: "{{ $root.Release.Name }}-router-public"
   namespace: {{ $root.Release.Namespace | quote }}
   labels:
     app.kubernetes.io/component: router
@@ -140,7 +140,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ $root.Values.deployment_name }}-ssh-proxy-public"
+  name: "{{ $root.Release.Name }}-ssh-proxy-public"
   namespace: {{ $root.Release.Namespace | quote }}
   labels:
     app.kubernetes.io/component: ssh-proxy

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -1,5 +1,4 @@
 system_domain: ~
-deployment_name: kubecf
 
 # Set or override job properties. The first level of the map is the instance group name. The second
 # level of the map is the job name. E.g.:

--- a/dev/kind/BUILD.bazel
+++ b/dev/kind/BUILD.bazel
@@ -1,8 +1,9 @@
 package(default_visibility = ["//visibility:public"])
 
 load(":def.bzl", "kind_start_binary", "kind_delete_binary")
+load("//:def.bzl", "project")
 
-CLUSTER_NAME = "kubecf"
+CLUSTER_NAME = project.deployment_name
 
 kind_start_binary(
     name = "start",

--- a/dev/kind/start.sh
+++ b/dev/kind/start.sh
@@ -36,4 +36,4 @@ docker exec "${CLUSTER_NAME}-control-plane" bash -c "cp /etc/kubernetes/pki/ca.c
 
 echo ""
 echo "Set your KUBECONFIG by running:"
-echo "export KUBECONFIG=\"\$(bazel run @kind//kind -- get kubeconfig-path --name=\"kubecf\")\""
+echo "export KUBECONFIG=\"\$(bazel run @kind//kind -- get kubeconfig-path --name=\"${CLUSTER_NAME}\")\""

--- a/dev/kubecf/BUILD.bazel
+++ b/dev/kubecf/BUILD.bazel
@@ -7,7 +7,7 @@ load("//:def.bzl", "project")
 helm_template(
     name = "rendered_template",
     values = glob(["**/*values.yaml"]),
-    install_name = "kubecf",
+    install_name = project.deployment_name,
     namespace = project.namespace,
     chart_package = "//deploy/helm/kubecf:chart",
 )

--- a/dev/kubecf/values.yaml
+++ b/dev/kubecf/values.yaml
@@ -1,1 +1,0 @@
-deployment_name: kubecf

--- a/testing/acceptance_tests/BUILD.bazel
+++ b/testing/acceptance_tests/BUILD.bazel
@@ -7,7 +7,7 @@ kubectl_patch(
     name = "acceptance_tests",
     namespace = project.namespace,
     resource_type = "ejob",
-    resource_name = "kubecf-acceptance-tests",
+    resource_name = "{deployment_name}-acceptance-tests".format(deployment_name = project.deployment_name),
     patch_type = "merge",
     patch_file = ":trigger.yaml",
 )

--- a/testing/smoke_tests/BUILD.bazel
+++ b/testing/smoke_tests/BUILD.bazel
@@ -9,7 +9,7 @@ kubectl_patch(
     name = "smoke_tests",
     namespace = project.namespace,
     resource_type = "ejob",
-    resource_name = "kubecf-smoke-tests",
+    resource_name = "{deployment_name}-smoke-tests".format(deployment_name = project.deployment_name),
     patch_type = "merge",
     patch_file = ":trigger.yaml",
 )


### PR DESCRIPTION
## Description
We do not need the extra knob, when the helm release name will work just
fine for a unique prefix on the resource names.

## Motivation and Context
Fixes #193

## How Has This Been Tested?
Locally deployed (minikube) and ran smoke tests, though that was before rebasing due to #205.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

This is technically breaking, as it changes the admin-visible configs.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

The deployment name does not appear to have been previously documented.