### PR TITLE
minikube: allow arbitrary extra options

### DIFF
--- a/dev/minikube/start.sh
+++ b/dev/minikube/start.sh
@@ -3,6 +3,7 @@
 set -o errexit -o nounset
 
 if ! "${MINIKUBE}" status > /dev/null; then
+  # shellcheck disable=SC2086
   "${MINIKUBE}" start \
     --kubernetes-version "${K8S_VERSION}" \
     --cpus "${VM_CPUS}" \
@@ -11,7 +12,8 @@ if ! "${MINIKUBE}" status > /dev/null; then
     --iso-url "${ISO_URL}" \
     ${VM_DRIVER:+--vm-driver "${VM_DRIVER}"} \
     --extra-config=apiserver.runtime-config=settings.k8s.io/v1alpha1=true \
-    --extra-config=apiserver.enable-admission-plugins=MutatingAdmissionWebhook,PodPreset
+    --extra-config=apiserver.enable-admission-plugins=MutatingAdmissionWebhook,PodPreset \
+    ${MINIKUBE_EXTRA_OPTIONS:-}
 
   # Enable hairpin by setting the docker0 promiscuous mode on.
   "${MINIKUBE}" ssh -- "sudo ip link set docker0 promisc on"

--- a/doc/dev/minikube.md
+++ b/doc/dev/minikube.md
@@ -90,6 +90,9 @@ uses the Diego scheduler.
 
 ### Access
 
+Accessing the cluster from outside of the minikube VM requires
+[ingress](#ingress) to be set up correctly.
+
 To access the cluster after the cf-operator has completed the
 deployment and all pods are active invoke:
 

--- a/doc/dev/minikube.md
+++ b/doc/dev/minikube.md
@@ -36,7 +36,7 @@ the intended deployment.
 
 ### Advanced configuration
 
-The local [Minikube Documentation](kube_minikube.md) explains the
+The local [Minikube Documentation](../kube/minikube.md) explains the
 various environment variables which can be used to configure the
 resources used by the cluster (CPUs, memory, disk size, etc.) in
 detail.

--- a/doc/kube/minikube.md
+++ b/doc/kube/minikube.md
@@ -46,3 +46,11 @@ Set the `K8S_VERSION` environment variable to override the default version.
 
 At the moment, only the VirtualBox and KVM2 drivers are working correctly. Set the `VM_DRIVER`
 environment variable to override the default. E.g. `VM_DRIVER=kvm2`.
+
+## Extra minikube options
+
+It is possible to set extra minikube options (e.g. to set a docker registry
+mirror) via the environment variable `MINIKUBE_EXTRA_OPTIONS`.  For example:
+```sh
+export MINIKUBE_EXTRA_OPTIONS="--registry-mirror http://registry.mirror.example:5000/"
+```

--- a/doc/kube/minikube.md
+++ b/doc/kube/minikube.md
@@ -28,9 +28,11 @@ bazel run //dev/minikube:delete
 The following three environment variables are used by the `start`
 target to allocate the resources used by the deployed Minikube:
 
-  - VM_CPUS - the number of CPUs Minikube will use.
-  - VM_MEMORY - the amount of RAM Minikube will be allowed to use.
-  - VM_DISK_SIZE - the disk size Minikube will be allowed to use.
+| Variable | Setting |
+| --- | --- |
+| `VM_CPUS` | the number of CPUs Minikube will use. |
+| `VM_MEMORY` | the amount of RAM Minikube will be allowed to use. |
+| `VM_DISK_SIZE` | the disk size Minikube will be allowed to use. |
 
 E.g.:
 


### PR DESCRIPTION
## Description
This lets us pass in extra arguments to minikube (but does not hard code which, since that does not make sense outside of the local context).

## Motivation and Context
I want to set up a local docker registry mirror; this _can_ be done in minikube, but requires extra arguments.  

## How Has This Been Tested?
I now have extra options to use a docker registry mirror on minikube (using @f0rmiga's opensuse image, as is default in kubecf).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
