### PR TITLE
mgmt: Add github stale configuration

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -2,7 +2,7 @@
 daysUntilStale: 60
 
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 7
+daysUntilClose: false
 
 # Issues with these labels will never be considered stale
 exemptLabels:
@@ -18,8 +18,8 @@ staleLabel: "Type: Stalled"
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
-  for your contributions.
+  recent activity. If this issue is still relevant then let us know how to help move it forward. 
+  Thank you for your contributions.
 
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: false

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,17 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - type: bug
+  - type: security
+# Label to use when marking an issue as stale
+staleLabel: Stalled
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,17 +1,25 @@
 # Number of days of inactivity before an issue becomes stale
 daysUntilStale: 60
+
 # Number of days of inactivity before a stale issue is closed
 daysUntilClose: 7
+
 # Issues with these labels will never be considered stale
 exemptLabels:
-  - type: bug
-  - type: security
+  - type: "Type: Bug"
+  - type: "Type: Security"
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
 # Label to use when marking an issue as stale
-staleLabel: Stalled
+staleLabel: "Type: Stalled"
+
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had
   recent activity. It will be closed if no further activity occurs. Thank you
   for your contributions.
+
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: false


### PR DESCRIPTION
## Description

GitHub Stale plugin will label issues and pull requests when without activity for more than 60 days and after 7 days it will close them.

## Motivation and Context

To have a lean and meaningful backlog.

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Configurations

## Checklist:
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
