### PR TITLE
Add helm lint support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,6 +18,7 @@ lint:
   script:
   - ./dev/linters/shellcheck.sh
   - ./dev/linters/yamllint.sh
+  - ./dev/linters/helmlint.sh
 
 build:chart:
   stage: build

--- a/dev/linters/BUILD.bazel
+++ b/dev/linters/BUILD.bazel
@@ -1,0 +1,12 @@
+sh_library(
+    name = "chart",
+    data = ["//deploy/helm/kubecf:chart"],
+)
+
+sh_test(
+    name = "helm",
+    srcs = ["@helm//helm"],
+    deps = [":chart"],
+    args = ["lint", "$(rootpath :chart)"],
+    size = "small",
+)

--- a/dev/linters/helmlint.sh
+++ b/dev/linters/helmlint.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset
+
+exec bazel test //dev/linters:helm

--- a/doc/Contribute.md
+++ b/doc/Contribute.md
@@ -97,20 +97,23 @@ associated documentation, if we have any.
 
 ## Linting
 
-Currently, 2 linters are available:
+Currently, 3 linters are available:
 
   - `dev/linters/shellcheck.sh`
   - `dev/linters/yamllint.sh`
+  - `dev/linters/helmlint.sh`
 
 Invoke these linters as
 
 ```sh
 dev/linters/shellcheck.sh
 dev/linters/yamllint.sh
+dev/linters/helmlint.sh
 ```
 
 to run shellcheck on all `.sh` files found in the entire checkout, or yamllint
-on all `.yaml` or `.yml` files respectively, and report any issues found.
+on all `.yaml` or `.yml` files respectively, and report any issues found.  The
+last option runs `helm lint` (without `--strict`) on the generated helm chart.
 
 ## Patching
 

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -14,3 +14,7 @@ The following linters are available:
 
     Runs yamllint on all `.{yaml,yml}` files found in the entire checkout
     and reports any issues found.
+
+  - `helmlint.sh`:
+
+    Runs `helm lint` on the generated `kubecf` chart and repos any errors found.


### PR DESCRIPTION
## Description
This adds support for running `helm lint` on the generated chart.

## Motivation and Context
Closes #23 (as this is the last missing linter).

## How Has This Been Tested?
Ran locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

## Additional information
I could not use `helm lint --strict` as too much of our code relies on accessing unset keys in dictionaries (and expecting them to evaluate to falsy), which is an error with `--strict`.