### PR TITLE
Fixed brain tests Role and RoleBinding

### DIFF
--- a/deploy/helm/kubecf/templates/brain-tests.yaml
+++ b/deploy/helm/kubecf/templates/brain-tests.yaml
@@ -23,6 +23,7 @@ apiVersion: "rbac.authorization.k8s.io/v1"
 kind: "Role"
 metadata:
   name: "{{ .Release.Name }}-test-role-brain"
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/component: "{{ .Release.Name }}-test-role-brain"
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
@@ -113,6 +114,7 @@ apiVersion: "rbac.authorization.k8s.io/v1"
 kind: "RoleBinding"
 metadata:
   name: "{{ .Release.Name }}-tests-brain-test-role-brain-binding"
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/component: "{{ .Release.Name }}-tests-brain-test-role-brain-binding"
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
@@ -123,6 +125,7 @@ metadata:
 subjects:
 - kind: "ServiceAccount"
   name: "{{ .Release.Name }}-tests-brain"
+  namespace: {{ .Release.Namespace | quote }}
 roleRef:
   apiGroup: "rbac.authorization.k8s.io"
   kind: "Role"


### PR DESCRIPTION
## Description

Added the missing namespace to the k8s resources.

## Motivation and Context

The namespace was missing from the brain-tests Role and RoleBinding resources.
It presented problematic on CI.

## How Has This Been Tested?

CI should be able to deploy kubecf.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
