### PR TITLE
Enable credhub instance group (only for user apps)

### DIFF
--- a/deploy/helm/kubecf/assets/operations/instance_groups/brain-tests.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/brain-tests.yaml
@@ -21,15 +21,17 @@
     - name: acceptance-tests-brain
       properties:
         acceptance_tests_brain:
-          domain:        ((system_domain))
-          apps_domain:   ((system_domain))
-          namespace:     {{ .Release.Namespace }}
-          org:           test-brain-org
-          password:      ((cf_admin_password))
-          space:         test-space-org
-          storage_class: {{ default "" .Values.kube.storage_class | quote }}
-          tcp_domain:    tcp.((system_domain))
-          user:          admin
+          domain:         ((system_domain))
+          apps_domain:    ((system_domain))
+          namespace:      {{ .Release.Namespace }}
+          org:            test-brain-org
+          password:       ((cf_admin_password))
+          space:          test-space-org
+          storage_class:  {{ default "" .Values.kube.storage_class | quote }}
+          tcp_domain:     tcp.((system_domain))
+          user:           admin
+          credhub_client: credhub_admin_client
+          credhub_secret: ((credhub_admin_client_secret))
         smoke_tests:
           api:                 api.((system_domain))
           apps_domain:         ((system_domain))

--- a/deploy/helm/kubecf/assets/operations/instance_groups/brain-tests.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/brain-tests.yaml
@@ -3,7 +3,7 @@
   value:
     name: brain-tests
     url: {{ include "kubecf.releaseURLLookup" (list .Values.releases "brain-tests") }}
-    version: v0.0.5
+    version: v0.0.6
     stemcell: {{ include "kubecf.stemcellLookup" (list .Values.releases "brain-tests") }}
 
 - path: /instance_groups/-

--- a/deploy/helm/kubecf/assets/operations/instance_groups/credhub.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/credhub.yaml
@@ -1,0 +1,20 @@
+---
+- type: replace
+  path: /instance_groups/name=credhub/jobs/name=credhub/provides?
+  value: { credhub: nil }
+- type: replace
+  path: /instance_groups/name=credhub/jobs/-
+  value:
+    name: route_registrar
+    release: routing
+    properties:
+      route_registrar:
+        routes:
+        - name: credhub
+          tls_port: 8844
+          server_cert_domain_san: credhub.service.cf.internal
+          registration_interval: 10s
+          tags:
+            component: credhub
+          uris:
+          - credhub.((system_domain))

--- a/deploy/helm/kubecf/assets/operations/instance_groups/router.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/router.yaml
@@ -47,6 +47,7 @@
 
 # Trust the diego_instance_identity_ca certificate - trusting its CA
 # is insufficient with the cf-operator
+# Also add the CredHub CA
 - type: replace
   path: /instance_groups/name=router/jobs/name=gorouter/properties/router/ca_certs
   value: |
@@ -54,3 +55,4 @@
     ((cc_tls.ca))
     ((uaa_ssl.ca))
     ((network_policy_server_external.ca))
+    ((credhub_ca.certificate))

--- a/deploy/helm/kubecf/assets/operations/temporary/remove_roles.yaml
+++ b/deploy/helm/kubecf/assets/operations/temporary/remove_roles.yaml
@@ -2,6 +2,4 @@
 # development. It should go away once all instance_groups work properly with cf-operator.
 
 - type: remove
-  path: /instance_groups/name=credhub
-- type: remove
   path: /instance_groups/name=rotate-cc-database-key

--- a/deploy/helm/kubecf/assets/operations/temporary/remove_variables.yaml
+++ b/deploy/helm/kubecf/assets/operations/temporary/remove_variables.yaml
@@ -1,5 +1,0 @@
-# This is a temporary file used for selectively removing variables during the initial development.
-# It should go away once all instance_groups work properly with cf-operator.
-
-- type: remove
-  path: /variables/name=credhub_encryption_password

--- a/deploy/helm/kubecf/templates/azs.yaml
+++ b/deploy/helm/kubecf/templates/azs.yaml
@@ -19,6 +19,8 @@ data:
     - type: remove
       path: /instance_groups/name=adapter/azs?
     - type: remove
+      path: /instance_groups/name=credhub/azs?
+    - type: remove
       path: /instance_groups/name=diego-api/azs?
     - type: remove
       path: /instance_groups/name=uaa/azs?

--- a/deploy/helm/kubecf/templates/sizing.yaml
+++ b/deploy/helm/kubecf/templates/sizing.yaml
@@ -33,6 +33,16 @@ data:
       value: 1
 {{- end }}
 
+{{- if .Values.sizing.credhub.instances }}
+    - type: replace
+      path: /instance_groups/name=credhub/instances
+      value: {{.Values.sizing.credhub.instances}}
+{{- else if not .Values.high_availability }}
+    - type: replace
+      path: /instance_groups/name=credhub/instances
+      value: 1
+{{- end }}
+
 {{- if .Values.features.eirini.enabled }}
 {{- if .Values.sizing.bits.instances }}
     - type: replace

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -56,6 +56,8 @@ sizing:
     instances: ~
   cc_worker:
     instances: ~
+  credhub:
+    instances: ~
   database:
     instances: 1
   diego_api:


### PR DESCRIPTION
## Description
This enables credhub, but _only_ as a thing for user applications: internal CF components do not attempt to use credhub (as the BOSH link is disabled).

## Motivation and Context
Fixes #202

## How Has This Been Tested?
Ran acceptance-tests-brain; requires the fixes in https://github.com/SUSE/brain-tests-release/pull/5

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has security implications.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
