### PR TITLE
Removed dev/kubecf/values.yaml

### DIFF
--- a/dev/kubecf/.gitignore
+++ b/dev/kubecf/.gitignore
@@ -1,2 +1,1 @@
 *values.yaml
-!values.yaml


### PR DESCRIPTION
## Description

The file `dev/kubecf/values.yaml` is currently empty and not needed anymore.

## Motivation and Context

We only had one value in this file before, which was `deployment_name`. Since we removed this property, this file has no use anymore.

## How Has This Been Tested?

N/A.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
