### PR TITLE
Removed ulimit calls

### DIFF
--- a/bosh/releases/pre_render_scripts/api/cloud_controller_ng/jobs/patch_cc_uploader_ctl.sh
+++ b/bosh/releases/pre_render_scripts/api/cloud_controller_ng/jobs/patch_cc_uploader_ctl.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset
+
+target="/var/vcap/all-releases/jobs-src/capi/cc_uploader/templates/cc_uploader_ctl.erb"
+sentinel="${target}.patch_sentinel"
+if [[ -f "${sentinel}" ]]; then
+  echo "Patch already applied. Skipping"
+  exit 0
+fi
+
+patch --verbose "${target}" <<'EOT'
+@@ -40,9 +40,6 @@
+         echo 1 > /proc/sys/net/ipv4/tcp_tw_reuse
+     fi
+
+-    # Allowed number of open file descriptors
+-    ulimit -n 100000
+-
+     # Work around for GOLANG 1.5.3 DNS bug
+     export GODEBUG=netdns=cgo
+EOT
+
+touch "${sentinel}"

--- a/bosh/releases/pre_render_scripts/api/cloud_controller_ng/jobs/patch_cloud_controller_api_ctl.sh
+++ b/bosh/releases/pre_render_scripts/api/cloud_controller_ng/jobs/patch_cloud_controller_api_ctl.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset
+
+target="/var/vcap/all-releases/jobs-src/capi/cloud_controller_ng/templates/cloud_controller_api_ctl.erb"
+sentinel="${target}.patch_sentinel"
+if [[ -f "${sentinel}" ]]; then
+  echo "Patch already applied. Skipping"
+  exit 0
+fi
+
+patch --verbose "${target}" <<'EOT'
+@@ -53,8 +53,6 @@
+   start)
+     setup_environment
+
+-    ulimit -c unlimited
+-
+     pid_guard "$PIDFILE" "Cloud controller ng"
+
+     exec /var/vcap/jobs/cloud_controller_ng/bin/cloud_controller_ng
+EOT
+
+touch "${sentinel}"

--- a/bosh/releases/pre_render_scripts/api/cloud_controller_ng/jobs/patch_file_server_ctl.sh
+++ b/bosh/releases/pre_render_scripts/api/cloud_controller_ng/jobs/patch_file_server_ctl.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset
+
+target="/var/vcap/all-releases/jobs-src/diego/file_server/templates/file_server_ctl.erb"
+sentinel="${target}.patch_sentinel"
+if [[ -f "${sentinel}" ]]; then
+  echo "Patch already applied. Skipping"
+  exit 0
+fi
+
+patch --verbose "${target}" <<'EOT'
+@@ -20,9 +20,6 @@
+
+     $bin_dir/set-file-server-kernel-params
+
+-    # Allowed number of open file descriptors
+-    ulimit -n 100000
+-
+     exec chpst -u vcap:vcap bash -c '/var/vcap/jobs/file_server/bin/file_server_as_vcap'
+
+     ;;
+EOT
+
+touch "${sentinel}"

--- a/bosh/releases/pre_render_scripts/database/mysql/jobs/patch_galera-healthcheck_ctl.sh
+++ b/bosh/releases/pre_render_scripts/database/mysql/jobs/patch_galera-healthcheck_ctl.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset
+
+target="/var/vcap/all-releases/jobs-src/cf-mysql/mysql/templates/galera-healthcheck_ctl.erb"
+sentinel="${target}.patch_sentinel"
+if [[ -f "${sentinel}" ]]; then
+  echo "Patch already applied. Skipping"
+  exit 0
+fi
+
+patch --verbose "${target}" <<'EOT'
+@@ -24,8 +24,6 @@
+
+     cd $package_dir
+
+-    ulimit -n <%= p('cf_mysql.mysql.max_open_files') %> # HIGH Ulimit for SST of lots of tables (in case we run the bootstrap errand)
+-
+     chpst -u vcap:vcap bash -c "
+       $package_dir/bin/galera-healthcheck \
+         -configPath=$job_dir/config/galera_healthcheck_config.yaml \
+
+EOT
+
+touch "${sentinel}"

--- a/bosh/releases/pre_render_scripts/database/mysql/jobs/patch_mariadb_ctl.sh
+++ b/bosh/releases/pre_render_scripts/database/mysql/jobs/patch_mariadb_ctl.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset
+
+target="/var/vcap/all-releases/jobs-src/cf-mysql/mysql/templates/mariadb_ctl.erb"
+sentinel="${target}.patch_sentinel"
+if [[ -f "${sentinel}" ]]; then
+  echo "Patch already applied. Skipping"
+  exit 0
+fi
+
+patch --verbose "${target}" <<'EOT'
+@@ -40,8 +40,6 @@
+ # add perl libraries to perl env
+ export PERL5LIB=$PERL5LIB:/var/vcap/packages/xtrabackup/lib/perl/5.18.2
+
+-ulimit -n <%= p('cf_mysql.mysql.max_open_files') %>
+-
+ if [[ ! -d "$RUN_DIR" ]]; then
+   mkdir -p $RUN_DIR
+ fi
+EOT
+
+touch "${sentinel}"

--- a/bosh/releases/pre_render_scripts/database/mysql/jobs/patch_pre-start-setup.sh
+++ b/bosh/releases/pre_render_scripts/database/mysql/jobs/patch_pre-start-setup.sh
@@ -3,27 +3,45 @@
 set -o errexit -o nounset
 
 target="/var/vcap/all-releases/jobs-src/cf-mysql/mysql/templates/pre-start-setup.erb"
-
-# Patch pre-start-setup.erb to play nice with BPM's persistent disk. Instead of checking for the
-# existence of the directory /var/vcap/store/mysql, it checks for the existence of the file
-# /var/vcap/store/mysql/setup_succeeded, which is also created in a command from this patch.
-PATCH=$(cat <<'EOT'
-82,84c82,84
-< if ! test -d ${datadir}; then
-<   log "pre-start setup script: making ${datadir} and running /var/vcap/packages/mariadb/scripts/mysql_install_db"
-<   mkdir -p ${datadir}
----
-> setup_control_file="${datadir}/setup_succeeded"
-> if ! test -e "${setup_control_file}"; then
->   log "pre-start setup script: running /var/vcap/packages/mariadb/scripts/mysql_install_db"
-89a90
->   touch "${setup_control_file}"
-EOT
-)
-
-# Only patch once
-if ! patch --reverse --dry-run -f "${target}" <<<"$PATCH" 2>&1  >/dev/null ; then
-  patch --verbose "${target}" <<<"$PATCH"
-else
+sentinel="${target}.patch_sentinel"
+if [[ -f "${sentinel}" ]]; then
   echo "Patch already applied. Skipping"
+  exit 0
 fi
+
+# Patch pre-start-setup.erb to:
+# 1. Remove ulimit call.
+# 2. Play nice with BPM's persistent disk. Instead of checking for the existence of the directory
+# /var/vcap/store/mysql, it checks for the existence of the file
+# /var/vcap/store/mysql/setup_succeeded, which is also created in a command from this patch.
+patch --verbose "${target}" <<'EOT'
+@@ -50,8 +50,6 @@
+ ln -sf $MARIADB_JOB_DIR/config/disable_mysql_cli_history.sh /etc/profile.d/disable_mysql_cli_history.sh
+ <% end %>
+
+-ulimit -n <%= p('cf_mysql.mysql.max_open_files') %>
+-
+ <% if p('cf_mysql.mysql.disable_auto_sst') %>
+ if [ -d ${datadir} ]; then
+   export DISABLE_SST=1
+@@ -79,14 +77,15 @@
+ check_mysql_disk_persistence
+ check_mysql_disk_capacity
+
+-if ! test -d ${datadir}; then
+-  log "pre-start setup script: making ${datadir} and running /var/vcap/packages/mariadb/scripts/mysql_install_db"
+-  mkdir -p ${datadir}
++setup_control_file="${datadir}/setup_succeeded"
++if ! test -e "${setup_control_file}"; then
++  log "pre-start setup script: running /var/vcap/packages/mariadb/scripts/mysql_install_db"
+   /var/vcap/packages/mariadb/scripts/mysql_install_db \
+          --defaults-file=/var/vcap/jobs/mysql/config/my.cnf \
+          --basedir=/var/vcap/packages/mariadb \
+          --user=vcap \
+          --datadir=${datadir} >> $LOG_FILE 2>> $LOG_FILE
++  touch "${setup_control_file}"
+ fi
+ chown -R vcap:vcap ${datadir}
+EOT
+
+touch "${sentinel}"

--- a/bosh/releases/pre_render_scripts/diego-api/bbs/jobs/patch_bbs_ctl.sh
+++ b/bosh/releases/pre_render_scripts/diego-api/bbs/jobs/patch_bbs_ctl.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset
+
+target="/var/vcap/all-releases/jobs-src/diego/bbs/templates/bbs_ctl.erb"
+sentinel="${target}.patch_sentinel"
+if [[ -f "${sentinel}" ]]; then
+  echo "Patch already applied. Skipping"
+  exit 0
+fi
+
+patch --verbose "${target}" <<'EOT'
+@@ -26,14 +26,6 @@
+
+     $bin_dir/set-bbs-kernel-params
+
+-    # Allowed number of open file descriptors (must be a positive integer)
+-    <%
+-    if !p('limits.open_files').is_a?(Integer) || p('limits.open_files') <= 0
+-      raise "limits.open_files must be a positive integer"
+-    end
+-    %>
+-    ulimit -n <%= p('limits.open_files') %>
+-
+     exec chpst -u vcap:vcap bash -c  '/var/vcap/jobs/bbs/bin/bbs_as_vcap'
+
+     ;;
+EOT
+
+touch "${sentinel}"

--- a/bosh/releases/pre_render_scripts/diego-api/locket/jobs/patch_locket_ctl.sh
+++ b/bosh/releases/pre_render_scripts/diego-api/locket/jobs/patch_locket_ctl.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset
+
+target="/var/vcap/all-releases/jobs-src/diego/locket/templates/locket_ctl.erb"
+sentinel="${target}.patch_sentinel"
+if [[ -f "${sentinel}" ]]; then
+  echo "Patch already applied. Skipping"
+  exit 0
+fi
+
+patch --verbose "${target}" <<'EOT'
+@@ -26,9 +26,6 @@
+
+     $bin_dir/set-locket-kernel-params
+
+-    # Allowed number of open file descriptors
+-    ulimit -n 100000
+-
+     exec chpst -u vcap:vcap bash -c  '/var/vcap/jobs/locket/bin/locket_as_vcap'
+
+     ;;
+EOT
+
+touch "${sentinel}"

--- a/bosh/releases/pre_render_scripts/diego-cell/rep/jobs/patch_rep_ctl.sh
+++ b/bosh/releases/pre_render_scripts/diego-cell/rep/jobs/patch_rep_ctl.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset
+
+target="/var/vcap/all-releases/jobs-src/diego/rep/templates/rep_ctl.erb"
+sentinel="${target}.patch_sentinel"
+if [[ -f "${sentinel}" ]]; then
+  echo "Patch already applied. Skipping"
+  exit 0
+fi
+
+patch --verbose "${target}" <<'EOT'
+@@ -39,9 +39,6 @@
+     $bin_dir/set-rep-kernel-params
+     $bin_dir/setup_mounted_data_dirs
+
+-    # Allowed number of open file descriptors
+-    ulimit -n 100000
+-
+     exec chpst -u vcap:vcap /var/vcap/jobs/rep/bin/rep_as_vcap
+
+     ;;
+EOT
+
+touch "${sentinel}"

--- a/bosh/releases/pre_render_scripts/router/gorouter/jobs/patch_pre-start.sh
+++ b/bosh/releases/pre_render_scripts/router/gorouter/jobs/patch_pre-start.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset
+
+target="/var/vcap/all-releases/jobs-src/routing/gorouter/templates/pre-start.erb"
+sentinel="${target}.patch_sentinel"
+if [[ -f "${sentinel}" ]]; then
+  echo "Patch already applied. Skipping"
+  exit 0
+fi
+
+patch --verbose "${target}" <<'EOT'
+@@ -27,6 +27,3 @@
+ <% else %>
+     echo "Not setting /proc/sys/net/ipv4 parameters, since I'm running inside a linux container"
+ <% end %>
+-
+-# Allowed number of open file descriptors
+-ulimit -n 100000
+EOT
+
+touch "${sentinel}"

--- a/bosh/releases/pre_render_scripts/scheduler/auctioneer/jobs/patch_auctioneer_ctl.sh
+++ b/bosh/releases/pre_render_scripts/scheduler/auctioneer/jobs/patch_auctioneer_ctl.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset
+
+target="/var/vcap/all-releases/jobs-src/diego/auctioneer/templates/auctioneer_ctl.erb"
+sentinel="${target}.patch_sentinel"
+if [[ -f "${sentinel}" ]]; then
+  echo "Patch already applied. Skipping"
+  exit 0
+fi
+
+patch --verbose "${target}" <<'EOT'
+@@ -18,9 +18,6 @@
+     mkdir -p $log_dir
+     chown -R vcap:vcap $log_dir
+
+-    # Allowed number of open file descriptors
+-    ulimit -n 100000
+-
+     exec chpst -u vcap:vcap bash -c '/var/vcap/jobs/auctioneer/bin/auctioneer_as_vcap'
+
+     ;;
+EOT
+
+touch "${sentinel}"

--- a/bosh/releases/pre_render_scripts/scheduler/ssh_proxy/jobs/patch_ssh_proxy_ctl.sh
+++ b/bosh/releases/pre_render_scripts/scheduler/ssh_proxy/jobs/patch_ssh_proxy_ctl.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset
+
+target="/var/vcap/all-releases/jobs-src/diego/ssh_proxy/templates/ssh_proxy_ctl.erb"
+sentinel="${target}.patch_sentinel"
+if [[ -f "${sentinel}" ]]; then
+  echo "Patch already applied. Skipping"
+  exit 0
+fi
+
+patch --verbose "${target}" <<'EOT'
+@@ -18,9 +18,6 @@
+     mkdir -p $log_dir
+     chown -R vcap:vcap $log_dir
+
+-    # Allowed number of open file descriptors
+-    ulimit -n 100000
+-
+     exec chpst -u vcap:vcap bash -c '/var/vcap/jobs/ssh_proxy/bin/ssh_proxy_as_vcap'
+
+     ;;
+EOT
+
+touch "${sentinel}"

--- a/deploy/helm/kubecf/assets/operations/instance_groups/router.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/router.yaml
@@ -54,3 +54,8 @@
     ((cc_tls.ca))
     ((uaa_ssl.ca))
     ((network_policy_server_external.ca))
+
+{{- $root := . -}}
+{{- range $path, $bytes := .Files.Glob "assets/operations/pre_render_scripts/router_*" }}
+{{ $root.Files.Get $path }}
+{{- end }}

--- a/deploy/helm/kubecf/assets/operations/instance_groups/scheduler.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/scheduler.yaml
@@ -85,3 +85,8 @@
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cfdot/properties/quarks?/bpm/processes
   value: []
+
+{{- $root := . -}}
+{{- range $path, $bytes := .Files.Glob "assets/operations/pre_render_scripts/scheduler_*" }}
+{{ $root.Files.Get $path }}
+{{- end }}


### PR DESCRIPTION
## Description

Removed all `ulimit` calls to set the open files limit. In some scenarios where the current value is lower than the one being set, it fails. E.g. on EKS, gorouter tries to set the limit to 100000 during the pre-start, while the current value is 65536.

## Motivation and Context

Fixes https://github.com/SUSE/kubecf/issues/250, unblocking QA testing of kubecf on public cloud.

## How Has This Been Tested?

Ran:

```
for pod in $(kubectl get pods --namespace kubecf --output name); do kubectl exec -it --namespace kubecf "${pod#"pod/"}" -- bash -c 'grep --color=auto -r "ulimit" /var/vcap/jobs/'; done
```

and verified that all `ulimit` calls are gone.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
