### PR TITLE
Refactored bpm scripts to be separate shell files

### DIFF
--- a/deploy/helm/kubecf/assets/operations/instance_groups/app-autoscaler.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/app-autoscaler.yaml
@@ -1003,34 +1003,8 @@
         - "-"
         - vcap
         - -c
-        - |
-          set -o errexit -o nounset
-
-          wait_for_file() {
-            local file_path="$1"
-            local timeout="${2:-30}"
-            until [[ -f "${file_path}" ]] || [[ "$timeout" == "0" ]]; do sleep 1; timeout=$(expr $timeout - 1); done
-            if [[ "${timeout}" == 0 ]]; then return 1; fi
-            return 0
-          }
-
-          source /var/vcap/jobs/postgres/bin/pgconfig.sh
-
-          /var/vcap/jobs/postgres/bin/postgres_ctl start
-          wait_for_file "${PIDFILE}" || {
-            echo "${PIDFILE} did not get created"
-            exit 1
-          }
-          trap '/var/vcap/jobs/postgres/bin/postgres_ctl stop' EXIT
-
-          /var/vcap/jobs/postgres/bin/pg_janitor_ctl start &
-
-          tail \
-            --pid "$(cat "${PIDFILE}")" \
-            --follow \
-            "${LOG_DIR}/startup.log" \
-            "${LOG_DIR}/pg_janitor_ctl.log" \
-            "${LOG_DIR}/pg_janitor_ctl.err.log"
+        - |-
+          {{- .Files.Get "assets/scripts/jobs/postgres/bpm_process.sh" | nindent 10 }}
 
 # TODO: set these skip_ssl_validation to false if the cf API (api.((system_domain))) public cert is provided by the user.
 - type: replace

--- a/deploy/helm/kubecf/assets/operations/instance_groups/database.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/database.yaml
@@ -410,7 +410,7 @@
       internal: 3306
     run:
       healthcheck:
-        mariadb_ctrl:
+        mariadb:
           readiness:
             exec:
               command:
@@ -425,40 +425,15 @@
               command: [pidof, mysqld]
     bpm:
       processes:
-      - name: mariadb_ctrl
+      - name: mariadb
         limits:
           open_files: 1048576
         persistent_disk: true
         executable: /bin/bash
         args:
           - -c
-          - |
-            wait_for_file() {
-              local file_path="$1"
-              local timeout="${2:-30}"
-              until [[ -f "${file_path}" ]] || [[ "$timeout" == "0" ]]; do sleep 1; timeout=$(expr $timeout - 1); done
-              if [[ "${timeout}" == 0 ]]; then return 1; fi
-              return 0
-            }
-
-            /var/vcap/jobs/mysql/bin/mariadb_ctl start
-
-            pid_file="/var/vcap/sys/run/mysql/mysql.pid"
-            log_file="/var/vcap/sys/log/mysql/mariadb_ctrl.combined.log"
-
-            wait_for_file "${pid_file}" || {
-              echo "${pid_file} did not get created"
-              exit 1
-            }
-
-            wait_for_file "${log_file}" || {
-              echo "${log_file} did not get created"
-              exit 1
-            }
-
-            tail \
-              --pid $(cat "${pid_file}") \
-              --follow "${log_file}"
+          - |-
+            {{- .Files.Get "assets/scripts/jobs/mariadb/bpm_process.sh" | nindent 12 }}
 
 {{- $root := . -}}
 {{- range $path, $bytes := .Files.Glob "assets/operations/pre_render_scripts/database_*" }}

--- a/deploy/helm/kubecf/assets/operations/instance_groups/database.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/database.yaml
@@ -410,7 +410,7 @@
       internal: 3306
     run:
       healthcheck:
-        mariadb:
+        mariadb_ctrl:
           readiness:
             exec:
               command:
@@ -425,7 +425,7 @@
               command: [pidof, mysqld]
     bpm:
       processes:
-      - name: mariadb
+      - name: mariadb_ctrl
         limits:
           open_files: 1048576
         persistent_disk: true

--- a/deploy/helm/kubecf/assets/scripts/jobs/mariadb/bpm_process.sh
+++ b/deploy/helm/kubecf/assets/scripts/jobs/mariadb/bpm_process.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset
+
+wait_for_file() {
+  local file_path="$1"
+  local timeout="${2:-30}"
+  timeout "${timeout}" bash -c "until [[ -f '${file_path}' ]]; do sleep 1; done"
+  return 0
+}
+
+/var/vcap/jobs/mysql/bin/mariadb_ctl start
+
+pid_file="/var/vcap/sys/run/mysql/mysql.pid"
+log_file="/var/vcap/sys/log/mysql/mariadb_ctrl.combined.log"
+
+wait_for_file "${pid_file}" || {
+  echo "${pid_file} did not get created"
+  exit 1
+}
+
+wait_for_file "${log_file}" || {
+  echo "${log_file} did not get created"
+  exit 1
+}
+
+tail \
+  --pid "$(cat "${pid_file}")" \
+  --follow "${log_file}"

--- a/deploy/helm/kubecf/assets/scripts/jobs/postgres/bpm_process.sh
+++ b/deploy/helm/kubecf/assets/scripts/jobs/postgres/bpm_process.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset
+
+wait_for_file() {
+  local file_path="$1"
+  local timeout="${2:-30}"
+  timeout "${timeout}" bash -c "until [[ -f '${file_path}' ]]; do sleep 1; done"
+  return 0
+}
+
+# shellcheck disable=SC1091
+source /var/vcap/jobs/postgres/bin/pgconfig.sh
+
+/var/vcap/jobs/postgres/bin/postgres_ctl start
+wait_for_file "${PIDFILE}" || {
+  echo "${PIDFILE} did not get created"
+  exit 1
+}
+trap '/var/vcap/jobs/postgres/bin/postgres_ctl stop' EXIT
+
+/var/vcap/jobs/postgres/bin/pg_janitor_ctl start &
+
+tail \
+  --pid "$(cat "${PIDFILE}")" \
+  --follow \
+  "${LOG_DIR}/startup.log" \
+  "${LOG_DIR}/pg_janitor_ctl.log" \
+  "${LOG_DIR}/pg_janitor_ctl.err.log"


### PR DESCRIPTION
## Description

Moving the scripts to shell files, we can lint and have IDE syntax highlighting.

## Motivation and Context

It's weird to have shell scripts indented in YAML as we don't take advantage of syntax highlighting and linting. Whenever possible, we should have shell files and interpolate them using the templating mechanism.

## How Has This Been Tested?

Deployed kubecf and checked that the scripts are working as intended.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
