### PR TITLE
kind/start: don't download files in the script

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -94,6 +94,12 @@ http_file(
     urls = [project.local_path_provisioner.url],
 )
 
+http_file(
+    name = "kube_dashboard",
+    sha256 = project.kube_dashboard.sha256,
+    urls = [project.kube_dashboard.url],
+)
+
 http_archive(
     name = "bazel_skylib",
     sha256 = project.skylib.sha256,

--- a/def.bzl
+++ b/def.bzl
@@ -94,6 +94,10 @@ project = struct(
         url = "https://raw.githubusercontent.com/rancher/local-path-provisioner/58cafaccef6645e135664053545ff94cb4bc4224/deploy/local-path-storage.yaml",
         sha256 = "df88b9a38420bb6d286953e06766abbc587e57f1f4eb5cb1c749fa53488cb4f7",
     ),
+    kube_dashboard = struct(
+        url = "https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.0-beta1/aio/deploy/recommended.yaml",
+        sha256 = "f849252870818a2971dfc3c4f8a8c5f58a57606bc2b5f221d7ab693e1d1190e0",
+    ),
     skylib = struct(
         version = "0.9.0",
         sha256 = "1dde365491125a3db70731e25658dfdd3bc5dbdfd11b840b3e987ecf043c7ca0",

--- a/dev/kind/def.bzl
+++ b/dev/kind/def.bzl
@@ -20,6 +20,8 @@ def _kind_impl(ctx):
         export KUBECTL="{kubectl}"
         export METRICS_SERVER="{metrics_server}"
         export K8S_VERSION="${{K8S_VERSION:-{k8s_version}}}"
+        export LOCAL_PATH_STORAGE_YAML="{local_path_storage_yaml}"
+        export KUBE_DASHBOARD_YAML="{kube_dashboard}"
         "{script}"
     """.format(
         kind = ctx.executable._kind.path,
@@ -27,6 +29,8 @@ def _kind_impl(ctx):
         kubectl = ctx.executable._kubectl.path,
         metrics_server = metrics_server_dir,
         k8s_version = ctx.attr.k8s_version,
+        local_path_storage_yaml = ctx.file._local_path_storage_yaml.short_path,
+        kube_dashboard = ctx.file._kube_dashboard.short_path,
         script = ctx.executable._script.path,
     )
     ctx.actions.write(executable, contents, is_executable = True)
@@ -34,6 +38,8 @@ def _kind_impl(ctx):
         ctx.executable._kind,
         ctx.executable._kubectl,
         ctx.executable._script,
+        ctx.file._local_path_storage_yaml,
+        ctx.file._kube_dashboard,
     ] + ctx.files._metrics_server
     return [DefaultInfo(
         executable = executable,
@@ -62,6 +68,14 @@ attrs = {
     "_metrics_server": attr.label(
         default = "@com_github_kubernetes_incubator_metrics_server//:deploy",
         allow_files = True,
+    ),
+    "_local_path_storage_yaml": attr.label(
+        default = "@local_path_provisioner//file",
+        allow_single_file = True,
+    ),
+    "_kube_dashboard": attr.label(
+        default = "@kube_dashboard//file",
+        allow_single_file = True,
     ),
 }
 

--- a/dev/kind/start.sh
+++ b/dev/kind/start.sh
@@ -17,14 +17,14 @@ else
 fi
 
 # Create a storage class.
-"${KUBECTL}" apply --filename https://raw.githubusercontent.com/rancher/local-path-provisioner/master/deploy/local-path-storage.yaml
+"${KUBECTL}" apply --filename "${LOCAL_PATH_STORAGE_YAML}"
 "${KUBECTL}" patch storageclass standard \
   --patch '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false", "storageclass.beta.kubernetes.io/is-default-class":"false"}}}'
 "${KUBECTL}" patch storageclass local-path \
   --patch '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true", "storageclass.beta.kubernetes.io/is-default-class":"true"}}}'
 
 # Deploy the kube dashboard.
-"${KUBECTL}" apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.0-beta1/aio/deploy/recommended.yaml
+"${KUBECTL}" apply -f "${KUBE_DASHBOARD_YAML}"
 
 # Create the metrics server.
 "${KUBECTL}" apply -f "${METRICS_SERVER}"


### PR DESCRIPTION
## Description
Move a couple downloads (via kube) to be done via bazel.

## Motivation and Context
Move as much network traffic into bazel, so that it can be cached (and in case the network intermittently fails, we might get lucky and end up with it already in cache).  Also, this way we get checksums so that we can know if the download fails / was changed remotely.

## How Has This Been Tested?
`bazel run //dev/kind:start`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
