### PR TITLE
Renamed mariadb bpm process

### DIFF
--- a/deploy/helm/kubecf/assets/operations/instance_groups/database.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/database.yaml
@@ -410,7 +410,7 @@
       internal: 3306
     run:
       healthcheck:
-        mariadb_ctrl:
+        mariadb:
           readiness:
             exec:
               command:
@@ -425,7 +425,7 @@
               command: [pidof, mysqld]
     bpm:
       processes:
-      - name: mariadb_ctrl
+      - name: mariadb
         limits:
           open_files: 1048576
         persistent_disk: true


### PR DESCRIPTION
## Description

A more appropriate name for the bpm process.

`mariadb_ctrl` -> `mariadb`

## Motivation and Context

A small cleanup in the bpm process.

## How Has This Been Tested?

Deployed kubecf, the name of the container changed.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
