### PR TITLE
Fix the bbs readiness probe

### DIFF
--- a/deploy/helm/kubecf/assets/operations/instance_groups/diego-api.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/diego-api.yaml
@@ -70,7 +70,7 @@
             # The /ping endpoint on the healthcheck endpoint is unusable for this readiness probe as
             # it always returns success if the server it up and running. The port 8889, on the other
             # hand, is useful because bbs will start listening on it only if it acquired the lock
-            # on the locket.
+            # via locket.
             # https://github.com/cloudfoundry/bbs/blob/513a9420c3244966c4391d3f3a830f1732f1398a/handlers/ping_handler.go#L17-L21
             tcpSocket:
               port: 8889

--- a/deploy/helm/kubecf/assets/operations/instance_groups/diego-api.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/diego-api.yaml
@@ -67,8 +67,10 @@
       healthcheck:
         bbs:
           readiness:
-            httpGet:
-              port: 8890
+            # The /ping endpoint on the healthcheck endpoint is unusable for this readiness probe.
+            # https://github.com/cloudfoundry/bbs/blob/513a9420c3244966c4391d3f3a830f1732f1398a/handlers/ping_handler.go#L17-L21
+            tcpSocket:
+              port: 8889
     post_start:
       condition:
         exec:

--- a/deploy/helm/kubecf/assets/operations/instance_groups/diego-api.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/diego-api.yaml
@@ -67,7 +67,10 @@
       healthcheck:
         bbs:
           readiness:
-            # The /ping endpoint on the healthcheck endpoint is unusable for this readiness probe.
+            # The /ping endpoint on the healthcheck endpoint is unusable for this readiness probe as
+            # it always returns success if the server it up and running. The port 889, on the other
+            # hand, is useful because bbs will start litening on it only if it acquired the lock
+            # on the locket.
             # https://github.com/cloudfoundry/bbs/blob/513a9420c3244966c4391d3f3a830f1732f1398a/handlers/ping_handler.go#L17-L21
             tcpSocket:
               port: 8889

--- a/deploy/helm/kubecf/assets/operations/instance_groups/diego-api.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/diego-api.yaml
@@ -68,7 +68,7 @@
         bbs:
           readiness:
             # The /ping endpoint on the healthcheck endpoint is unusable for this readiness probe as
-            # it always returns success if the server it up and running. The port 889, on the other
+            # it always returns success if the server it up and running. The port 8889, on the other
             # hand, is useful because bbs will start litening on it only if it acquired the lock
             # on the locket.
             # https://github.com/cloudfoundry/bbs/blob/513a9420c3244966c4391d3f3a830f1732f1398a/handlers/ping_handler.go#L17-L21

--- a/deploy/helm/kubecf/assets/operations/instance_groups/diego-api.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/diego-api.yaml
@@ -71,7 +71,6 @@
             # it always returns success if the server it up and running. The port 8889, on the other
             # hand, is useful because bbs will start listening on it only if it acquired the lock
             # via locket.
-            # https://github.com/cloudfoundry/bbs/blob/513a9420c3244966c4391d3f3a830f1732f1398a/handlers/ping_handler.go#L17-L21
             tcpSocket:
               port: 8889
     post_start:

--- a/deploy/helm/kubecf/assets/operations/instance_groups/diego-api.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/diego-api.yaml
@@ -69,7 +69,7 @@
           readiness:
             # The /ping endpoint on the healthcheck endpoint is unusable for this readiness probe as
             # it always returns success if the server it up and running. The port 8889, on the other
-            # hand, is useful because bbs will start litening on it only if it acquired the lock
+            # hand, is useful because bbs will start listening on it only if it acquired the lock
             # on the locket.
             # https://github.com/cloudfoundry/bbs/blob/513a9420c3244966c4391d3f3a830f1732f1398a/handlers/ping_handler.go#L17-L21
             tcpSocket:


### PR DESCRIPTION
## Description

The readiness probe for `bbs` was broken given that it always responded as healthy while not being.

## Motivation and Context

We want the `bbs` readiness probe to respond correctly so that the service endpoints can route to the instance that acquired the lock.

## How Has This Been Tested?

Deployed kubecf and ran CATS.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
