### PR TITLE
Replaced yaml2json with yq

### DIFF
--- a/.drone/pipelines/default/steps/deploy/wait_kubecf.sh
+++ b/.drone/pipelines/default/steps/deploy/wait_kubecf.sh
@@ -27,7 +27,7 @@ while IFS='' read -r line; do instance_groups+=("${line}"); done < <(
     --namespace "${KUBECF_NAMESPACE}" \
     --output jsonpath='{ .data.manifest\.yaml }' \
     | base64 --decode \
-    | yq \
+    | yq read --tojson - \
     | jq -r '.instance_groups[] | select(.lifecycle != "errand") | select (.lifecycle != "auto-errand") | .name'
 )
 

--- a/.drone/pipelines/default/steps/deploy/wait_kubecf.sh
+++ b/.drone/pipelines/default/steps/deploy/wait_kubecf.sh
@@ -27,7 +27,7 @@ while IFS='' read -r line; do instance_groups+=("${line}"); done < <(
     --namespace "${KUBECF_NAMESPACE}" \
     --output jsonpath='{ .data.manifest\.yaml }' \
     | base64 --decode \
-    | yaml2json \
+    | yq \
     | jq -r '.instance_groups[] | select(.lifecycle != "errand") | select (.lifecycle != "auto-errand") | .name'
 )
 

--- a/.gitlab/pipelines/runtime/binaries.sh
+++ b/.gitlab/pipelines/runtime/binaries.sh
@@ -8,5 +8,5 @@ K3S="$(bazel run //rules/external_binary:k3s 2> /dev/null)"
 export K3S
 JQ="$(bazel run //rules/external_binary:jq 2> /dev/null)"
 export JQ
-YAML2JSON="$(bazel run //rules/external_binary:yaml2json 2> /dev/null)"
-export YAML2JSON
+YQ="$(bazel run //rules/external_binary:yq 2> /dev/null)"
+export YQ

--- a/.gitlab/pipelines/stages/deploy/wait_kubecf.sh
+++ b/.gitlab/pipelines/stages/deploy/wait_kubecf.sh
@@ -29,7 +29,7 @@ while IFS='' read -r line; do instance_groups+=("${line}"); done < <(
     --namespace "${KUBECF_NAMESPACE}" \
     --output jsonpath='{ .data.manifest\.yaml }' \
     | base64 --decode \
-    | "${YAML2JSON}" \
+    | "${YQ}" read --tojson - \
     | "${JQ}" -r '.instance_groups[] | select(.lifecycle != "errand") | select (.lifecycle != "auto-errand") | .name'
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,7 +16,6 @@ load(":def.bzl", "project")
     "kind",
     "kubectl",
     "shellcheck",
-    "yaml2json",
     "yq",
 ]]
 

--- a/def.bzl
+++ b/def.bzl
@@ -170,22 +170,6 @@ project = struct(
             },
         },
     ),
-    yaml2json = struct(
-        platforms = {
-            "darwin": {
-                "url": "https://github.com/bronze1man/yaml2json/releases/download/v1.3/yaml2json_darwin_amd64",
-                "sha256": "5ea7e2bddf13721e68ae38b81093e8d539456af2cd22c7a1b0923e45a765c636",
-            },
-            "linux": {
-                "url": "https://github.com/bronze1man/yaml2json/releases/download/v1.3/yaml2json_linux_amd64",
-                "sha256": "e792647dd757c974351ea4ad35030852af97ef9bbbfb9594f0c94317e6738e55",
-            },
-            "windows": {
-                "url": "https://github.com/bronze1man/yaml2json/releases/download/v1.3/yaml2json_windows_amd64.exe",
-                "sha256": "a73fb27e36e30062c48dc0979c96afbbe25163e0899f6f259b654d56fda5cc26",
-            },
-        },
-    ),
     drone = struct(
         server = struct(
             app_name = "kubecf-drone-ci-server",

--- a/rules/external_binary/BUILD.bazel
+++ b/rules/external_binary/BUILD.bazel
@@ -13,6 +13,5 @@ load(":def.bzl", "binary_location")
     "kind",
     "kubectl",
     "shellcheck",
-    "yaml2json",
     "yq",
 ]]


### PR DESCRIPTION
## Description

Since `yq` has more options than `yaml2json`, and we introduced it in the project already, this PR removes `yaml2json` completely from the project.

## Motivation and Context

`yaml2json` was introduced in the past to simply convert YAML to JSON, but it's not capable of doing the inverse conversion - JSON to YAML. We then introduced `yq`, but left some usages of `yaml2json` behind.

## How Has This Been Tested?

The scripts using `yaml2json` and `yq` are part of the CI.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
