### PR TITLE
Removing sizing for singleton instance groups

### DIFF
--- a/deploy/helm/kubecf/templates/sizing.yaml
+++ b/deploy/helm/kubecf/templates/sizing.yaml
@@ -70,15 +70,6 @@ data:
       path: /instance_groups/name=asnozzle/instances
       value: 1
 {{- end }}
-{{- if .Values.sizing.asdatabase.instances }}
-    - type: replace
-      path: /instance_groups/name=asdatabase/instances
-      value: {{.Values.sizing.asdatabase.instances}}
-{{- else if not .Values.high_availability }}
-    - type: replace
-      path: /instance_groups/name=asdatabase/instances
-      value: 1
-{{- end }}
 {{- end }}
 
 {{- if .Values.sizing.auctioneer.instances }}
@@ -123,15 +114,9 @@ data:
 {{- end }}
 
 {{- if not .Values.features.external_database.enabled }}
-{{- if .Values.sizing.database.instances }}
-    - type: replace
-      path: /instance_groups/name=database/instances
-      value: {{.Values.sizing.database.instances}}
-{{- else if not .Values.high_availability }}
     - type: replace
       path: /instance_groups/name=database/instances
       value: 1
-{{- end }}
 {{- end }}
 
 {{- if .Values.sizing.diego_api.instances }}
@@ -213,16 +198,6 @@ data:
 {{- else if not .Values.high_availability }}
     - type: replace
       path: /instance_groups/name=scheduler/instances
-      value: 1
-{{- end }}
-
-{{- if .Values.sizing.singleton_blobstore.instances }}
-    - type: replace
-      path: /instance_groups/name=singleton-blobstore/instances
-      value: {{.Values.sizing.singleton_blobstore.instances}}
-{{- else if not .Values.high_availability }}
-    - type: replace
-      path: /instance_groups/name=singleton-blobstore/instances
       value: 1
 {{- end }}
 

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -81,8 +81,6 @@ sizing:
     instances: ~
   asapi:
     instances: ~
-  asdatabase:
-    instances: 1
   asmetrics:
     instances: ~
   asnozzle:
@@ -93,8 +91,6 @@ sizing:
     instances: ~
   cc_worker:
     instances: ~
-  database:
-    instances: 1
   diego_api:
     instances: ~
   diego_cell:
@@ -112,8 +108,6 @@ sizing:
   routing_api:
     instances: ~
   scheduler:
-    instances: ~
-  singleton_blobstore:
     instances: ~
   uaa:
     instances: ~


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes https://github.com/SUSE/kubecf/issues/275.

## Motivation and Context
The idea is to remove setting custom sizing for instance groups that are singleton.  

## How Has This Been Tested?
Locally on `minikube`.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
