### PR TITLE
Set chart versions for kubecf

### DIFF
--- a/def.bzl
+++ b/def.bzl
@@ -1,8 +1,8 @@
 project = struct(
     deployment_name = "kubecf",
     namespace = "kubecf",
-    chart_version = "3.0.0",
-    app_version = "2.0",
+    chart_version = "0.1.0",
+    app_version = "0.1.0",
     cf_deployment = struct(
         version = "12.18.0",
         sha256 = "1aeb7fa2bbd78ac4837c2aeaa4b9dc9567bc498f08f7fd744da556e672788991",


### PR DESCRIPTION
## Description

The kubecf chart versions should be reset.

## Motivation and Context

Kubecf will release version 0.1.0.

## How Has This Been Tested?

CI

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
