### PR TITLE
Fix post-start for diego-api passive instance(s)

### DIFF
--- a/deploy/helm/kubecf/assets/operations/instance_groups/diego-api.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/diego-api.yaml
@@ -73,13 +73,6 @@
             # via locket.
             tcpSocket:
               port: 8889
-    post_start:
-      condition:
-        exec:
-          command:
-          - sh
-          - -c
-          - ss -nlt sport = 8889 | grep "LISTEN.*:8889"
 
 - type: replace
   path: /instance_groups/name=diego-api/jobs/name=cfdot/properties/quarks?/bpm/processes


### PR DESCRIPTION
## Description

The post-start condition was timing out on the `diego-api` passive instance(s) as it was waiting for the instance to become ready.

Since we don't need to wait for the instances to be ready to execute the post-start script, this commit removes the post-start condition.

## Motivation and Context

On every 15 minutes, the passive instance(s) of the `diego-api` would restart due to the post-start timeout set on the `container-run` of cf-operator.

https://github.com/cloudfoundry-incubator/cf-operator/blob/master/container-run/pkg/containerrun/containerrun.go#L20

https://github.com/cloudfoundry-incubator/cf-operator/blob/master/container-run/pkg/containerrun/containerrun.go#L73

## How Has This Been Tested?

Deployed kubecf with 2 instances of the `diego-api` and waited > 15 minutes, asserting that it doesn't restart anymore.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
