### PR TITLE
Fix Drone CI

### DIFF
--- a/.drone/pipelines/default/steps/deploy/kubecf.sh
+++ b/.drone/pipelines/default/steps/deploy/kubecf.sh
@@ -21,35 +21,35 @@ helm template "${chart}" \
   --name "${KUBECF_INSTALL_NAME}" \
   --namespace "${KUBECF_NAMESPACE}" \
   --values <(cat <<EOF
-  system_domain: "${system_domain}"
+system_domain: "${system_domain}"
 
-  services:
-    router:
-      externalIPs:
-      - ${node_ip}
-    ssh-proxy:
-      externalIPs:
-      - ${node_ip}
-    tcp-router:
-      externalIPs:
-      - ${node_ip}
+services:
+  router:
+    externalIPs:
+    - ${node_ip}
+  ssh-proxy:
+    externalIPs:
+    - ${node_ip}
+  tcp-router:
+    externalIPs:
+    - ${node_ip}
 
-  features:
-    eirini:
-      enabled: ${EIRINI_ENABLED}
+features:
+  eirini:
+    enabled: ${EIRINI_ENABLED}
 
-  properties:
+properties:
+  acceptance-tests:
     acceptance-tests:
-      acceptance-tests:
-        acceptance_tests:
-          ginkgo:
-            slow_spec_threshold: 300
+      acceptance_tests:
+        ginkgo:
+          slow_spec_threshold: 300
 
-  testing:
-    cf_acceptance_tests:
-      enabled: true
-    smoke_tests:
-      enabled: true
+testing:
+  cf_acceptance_tests:
+    enabled: true
+  smoke_tests:
+    enabled: true
 EOF
 ) \
   | kubectl apply -f -

--- a/.drone/pipelines/default/steps/deploy/kubecf.sh
+++ b/.drone/pipelines/default/steps/deploy/kubecf.sh
@@ -44,6 +44,7 @@ properties:
       acceptance_tests:
         ginkgo:
           slow_spec_threshold: 300
+          nodes: 2
 
 testing:
   cf_acceptance_tests:

--- a/.drone/pipelines/default/steps/deploy/kubecf.sh
+++ b/.drone/pipelines/default/steps/deploy/kubecf.sh
@@ -53,6 +53,7 @@ testing:
 
 kube:
   service_cluster_ip_range: 0.0.0.0/0
+  pod_cluster_ip_range: 0.0.0.0/0
 EOF
 ) \
   | kubectl apply -f -

--- a/.drone/pipelines/default/steps/deploy/kubecf.sh
+++ b/.drone/pipelines/default/steps/deploy/kubecf.sh
@@ -50,6 +50,9 @@ testing:
     enabled: true
   smoke_tests:
     enabled: true
+
+kube:
+  service_cluster_ip_range: 0.0.0.0/0
 EOF
 ) \
   | kubectl apply -f -


### PR DESCRIPTION
## Description

Fixes Drone CI scripts to get it back to business.

## Motivation and Context

With the latest changes for releasing kubecf 0.1.0, Drone CI was left behind on the configuration.

## How Has This Been Tested?

Get Drone CI running.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
