### PR TITLE
Drone registry caches

### DIFF
--- a/.drone/deploy/runner/def.bzl
+++ b/.drone/deploy/runner/def.bzl
@@ -9,6 +9,7 @@ def _start_drone_runner_impl(ctx):
         template = ctx.file._script_template,
         output = script,
         substitutions = {
+            "{network_name}": ctx.attr._network_name,
             "{rpc_host}": ctx.attr._rpc_host,
             "{rpc_proto}": ctx.attr._rpc_proto,
             "{runner_capacity}": ctx.attr._runner_capacity,
@@ -23,6 +24,9 @@ def _start_drone_runner_impl(ctx):
 start_drone_runner = rule(
     implementation = _start_drone_runner_impl,
     attrs = {
+        "_network_name": attr.string(
+            default = project.drone.runner.network.name,
+        ),
         "_rpc_host": attr.string(
             default = project.drone.runner.rpc_host,
         ),

--- a/.drone/deploy/runner/def.bzl
+++ b/.drone/deploy/runner/def.bzl
@@ -28,10 +28,10 @@ start_drone_runner = rule(
             default = project.drone.runner.network.name,
         ),
         "_rpc_host": attr.string(
-            default = project.drone.runner.rpc_host,
+            default = project.drone.runner.rpc.host,
         ),
         "_rpc_proto": attr.string(
-            default = project.drone.runner.rpc_proto,
+            default = project.drone.runner.rpc.proto,
         ),
         "_runner_capacity": attr.string(
             default = str(project.drone.runner.capacity),

--- a/.drone/deploy/runner/start.sh
+++ b/.drone/deploy/runner/start.sh
@@ -31,3 +31,27 @@ docker run \
   --env "DRONE_RUNNER_CAPACITY={runner_capacity}" \
   --restart always \
   "drone/drone-runner-docker:{runner_image_version}@sha256:{runner_image_sha256}"
+
+# ==================================================================================================
+# Start the image registry caches.
+docker run \
+  --name kubecf-drone-ci-registry-dockerio \
+  --detach \
+  --volume /tmp/drone/docker/var/lib/registry:/var/lib/registry \
+  --env "REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io" \
+  --restart always \
+  registry:2
+
+docker run \
+  --name kubecf-drone-ci-registry-registrysusecom \
+  --detach \
+  --volume /tmp/drone/docker/var/lib/registry:/var/lib/registry \
+  --env "REGISTRY_PROXY_REMOTEURL=https://registry.suse.com" \
+  --restart always \
+  registry:2
+
+# ==================================================================================================
+# Connect the image registry caches to the kubecf-drone-ci network.
+docker network create "{network_name}"
+docker network connect "{network_name}" kubecf-drone-ci-registry-dockerio
+docker network connect "{network_name}" kubecf-drone-ci-registry-registrysusecom

--- a/.drone/pipelines/default/steps/deploy/kind.sh
+++ b/.drone/pipelines/default/steps/deploy/kind.sh
@@ -8,3 +8,22 @@ source ".drone/pipelines/default/runtime/binaries.sh"
 source ".drone/pipelines/default/runtime/config.sh"
 
 bazel run //dev/kind:start
+
+# ==================================================================================================
+# Connect the kind container to the kubecf-drone-ci network.
+# It allows the k8s cluster to use the image registry caches running on the same host Docker daemon.
+docker network connect \
+  kubecf-drone-ci \
+  kubecf-control-plane
+
+docker exec -i kubecf-control-plane \
+  bash -c 'cat >> "/etc/containerd/config.toml"' <<EOT
+
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+  endpoint = ["http://kubecf-drone-ci-registry-dockerio:5000"]
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."registry.suse.com"]
+  endpoint = ["http://kubecf-drone-ci-registry-registrysusecom:5000"]
+EOT
+
+docker exec -i kubecf-control-plane \
+  bash -c 'service containerd restart'

--- a/def.bzl
+++ b/def.bzl
@@ -188,6 +188,9 @@ project = struct(
             rpc_host = "kubecf-drone-ci-server.herokuapp.com",
             rpc_proto = "https",
             capacity = 1,
+            network = struct(
+                name = "kubecf-drone-ci",
+            ),
             image = struct(
                 version = 1,
                 sha256 = "eb09cdffd60b685fc76dc15c019a74829ba1632c27cf949ce271a792e7386597",

--- a/def.bzl
+++ b/def.bzl
@@ -185,8 +185,6 @@ project = struct(
             ),
         ),
         runner = struct(
-            rpc_host = "kubecf-drone-ci-server.herokuapp.com",
-            rpc_proto = "https",
             capacity = 1,
             network = struct(
                 name = "kubecf-drone-ci",
@@ -194,6 +192,10 @@ project = struct(
             image = struct(
                 version = 1,
                 sha256 = "eb09cdffd60b685fc76dc15c019a74829ba1632c27cf949ce271a792e7386597",
+            ),
+            rpc = struct(
+                host = "kubecf-drone-ci-server.herokuapp.com",
+                proto = "https",
             ),
         ),
     ),

--- a/dev/kind/start.sh
+++ b/dev/kind/start.sh
@@ -42,6 +42,9 @@ data:
       loadbalance
     }
 EOT
+
+  # Make the node trust Kube's CA.
+  docker exec "${CLUSTER_NAME}-control-plane" bash -c "cp /etc/kubernetes/pki/ca.crt /usr/local/share/ca-certificates/kube-ca.crt;update-ca-certificates;service containerd restart"
 else
   echo "Kind is already started"
 fi
@@ -58,6 +61,3 @@ fi
 
 # Create the metrics server.
 "${KUBECTL}" apply -f "${METRICS_SERVER}"
-
-# Make the node trust Kube's CA.
-docker exec "${CLUSTER_NAME}-control-plane" bash -c "cp /etc/kubernetes/pki/ca.crt /usr/local/share/ca-certificates/kube-ca.crt;update-ca-certificates;service containerd restart"


### PR DESCRIPTION
## Description

Adds image registry caches for Drone CI. It reduces the consumed bandwidth for downloading the images while also speeding up the time to deploy the pods.

## Motivation and Context

We want to reduce as much as possible the time spent by the CI pipelines in order to iterate faster on kubecf.

## How Has This Been Tested?

- Assembled all the pieces manually on a local cluster.
- Drone CI will test it.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
