### PR TITLE
[GKE] allow setting svc spec.loadBalancerIP for GKE reserved/static IPs

### DIFF
--- a/deploy/helm/kubecf/templates/ingress.yaml
+++ b/deploy/helm/kubecf/templates/ingress.yaml
@@ -134,6 +134,9 @@ spec:
   {{- if $service.clusterIP }}
   clusterIP: {{ $service.clusterIP | quote }}
   {{- end }}
+  {{- if $service.loadBalancerIP }}
+  loadBalancerIP: {{ $service.loadBalancerIP | quote }}
+  {{- end }}
 {{- end }}
 ---
 {{- with $service := index .Values.services "ssh-proxy" }}
@@ -165,6 +168,9 @@ spec:
   {{- end }}
   {{- if $service.clusterIP }}
   clusterIP: {{ $service.clusterIP | quote }}
+  {{- end }}
+  {{- if $service.loadBalancerIP }}
+  loadBalancerIP: {{ $service.loadBalancerIP | quote }}
   {{- end }}
 {{- end }}
 ---
@@ -200,6 +206,9 @@ spec:
   {{- end }}
   {{- if $service.clusterIP }}
   clusterIP: {{ $service.clusterIP | quote }}
+  {{- end }}
+  {{- if $service.loadBalancerIP }}
+  loadBalancerIP: {{ $service.loadBalancerIP | quote }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -29,7 +29,7 @@ kube:
   # The storage class to be used for the instance groups that need it (e.g. bits, database and
   # singleton-blobstore). If it's not set, the default storage class will be used.
   storage_class: ~
-  # The service_cluster_ip_range and pos_cluster_ip_range are used by the internal security group
+  # The service_cluster_ip_range and pod_cluster_ip_range are used by the internal security group
   # definition to allow apps to communicate with internal service brokers (e.g. credhub).
   # service_cluster_ip_range can be fetched with the following command, assuming that the API
   # server started with the `--service-cluster-ip-range` flag:


### PR DESCRIPTION
[GKE] To use a reserved/static IP for LoadBalancer services you need to set `spec.loadBalancerIP`, rather than `spec.externalIPs`. This PR allows the following values to be set for GKE:

```yaml
services:
  router:
    loadBalancerIP: 34.82.240.78
    externalIPs: []
  ssh-proxy:
    loadBalancerIP: 34.82.240.79
    externalIPs: []
  tcp-router:
    loadBalancerIP: 34.82.240.80
    externalIPs: []
```

## How Has This Been Tested?

* against cf-operator v1.0.0
* on GKE
* only for `services.router.loadBalancerIP` to confirm my kube service switched to use my reserved IP

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
