### PR TITLE
CCDB encryption key rotation

### DIFF
--- a/deploy/helm/kubecf/assets/operations/instance_groups/api.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/api.yaml
@@ -53,8 +53,9 @@
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/default_staging_security_groups/-
   value: internal
 
-# These replaces set their default values explicitly in order to the rotate-cc-database-key errand
-# resolve the BOSH link correctly.
+# These operations set the default values explicitly in order to get the rotate-cc-database-key
+# errand working. Without them, the rotate-cc-database-key errand is not able to resolve the CC BOSH
+# link correctly.
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/ccdb/max_connections?
   value: 25

--- a/deploy/helm/kubecf/assets/operations/instance_groups/api.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/api.yaml
@@ -53,6 +53,46 @@
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/default_staging_security_groups/-
   value: internal
 
+# These replaces set their default values explicitly in order to the rotate-cc-database-key errand
+# resolve the BOSH link correctly.
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/ccdb/max_connections?
+  value: 25
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/ccdb/pool_timeout?
+  value: 10
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/ccdb/ssl_verify_hostname?
+  value: true
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/ccdb/read_timeout?
+  value: 3600
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/ccdb/connection_validation_timeout?
+  value: 3600
+
+{{- range $keyLabel := .Values.ccdb.encryption.rotation.key_labels }}
+- type: replace
+  path: /variables/-
+  value:
+    name: {{ $keyLabel | quote }}
+    type: password
+{{- end }}
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/database_encryption?
+  value: &encryption_info
+    keys:
+      {{- range $keyLabel := .Values.ccdb.encryption.rotation.key_labels }}
+      {{ $keyLabel }}: "(({{ $keyLabel }}))"
+      {{- end }}
+    current_key_label: {{ .Values.ccdb.encryption.rotation.current_key_label | quote }}
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/database_encryption?
+  value: *encryption_info
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/database_encryption?
+  value: *encryption_info
+
 # core_file_pattern should be disabled as CC is not running on a VM.
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/core_file_pattern?

--- a/deploy/helm/kubecf/assets/operations/instance_groups/api.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/api.yaml
@@ -92,7 +92,7 @@
       {{- range $keyLabel := .Values.ccdb.encryption.rotation.key_labels }}
       ccdb_key_label_{{ $keyLabel }}: "((ccdb_key_label_{{ $keyLabel }}))"
       {{- end }}
-    current_key_label: {{ .Values.ccdb.encryption.rotation.current_key_label | quote }}
+    current_key_label: "ccdb_key_label_{{ .Values.ccdb.encryption.rotation.current_key_label }}"
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/database_encryption?
   value: *encryption_info

--- a/deploy/helm/kubecf/assets/operations/instance_groups/api.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/api.yaml
@@ -76,7 +76,7 @@
 - type: replace
   path: /variables/-
   value:
-    name: {{ $keyLabel | quote }}
+    name: "ccdb_key_label_{{ $keyLabel }}"
     type: password
 {{- end }}
 - type: replace
@@ -84,7 +84,7 @@
   value: &encryption_info
     keys:
       {{- range $keyLabel := .Values.ccdb.encryption.rotation.key_labels }}
-      {{ $keyLabel }}: "(({{ $keyLabel }}))"
+      ccdb_key_label_{{ $keyLabel }}: "((ccdb_key_label_{{ $keyLabel }}))"
       {{- end }}
     current_key_label: {{ .Values.ccdb.encryption.rotation.current_key_label | quote }}
 - type: replace

--- a/deploy/helm/kubecf/assets/operations/instance_groups/api.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/api.yaml
@@ -73,6 +73,12 @@
   value: 3600
 
 {{- range $keyLabel := .Values.ccdb.encryption.rotation.key_labels }}
+{{- if not (regexMatch "^[a-z]+[a-z0-9_]*[a-z0-9]+$" $keyLabel) }}
+{{ fail "One or more items in ccdb.encryption.rotation.key_labels don't match the regex /^[a-z]+[a-z0-9_]*[a-z0-9]+$/" }}
+{{- end }}
+{{- if gt (len $keyLabel) 240 }}
+{{ fail "One or more items in ccdb.encryption.rotation.key_labels exceed the maximum length of 240 characters" }}
+{{- end }}
 - type: replace
   path: /variables/-
   value:

--- a/deploy/helm/kubecf/assets/operations/temporary/remove_roles.yaml
+++ b/deploy/helm/kubecf/assets/operations/temporary/remove_roles.yaml
@@ -1,5 +1,0 @@
-# This is a temporary file used for selectively removing instance_groups during the initial
-# development. It should go away once all instance_groups work properly with cf-operator.
-
-- type: remove
-  path: /instance_groups/name=rotate-cc-database-key

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -222,6 +222,14 @@ testing:
   smoke_tests:
     enabled: true
 
+ccdb:
+  encryption:
+    rotation:
+      # Key labels must be < 256 characters long.
+      key_labels:
+      - encryption_key_0
+      current_key_label: encryption_key_0
+
 operations:
   # A list of configmap names that should be applied to the BOSH manifest.
   custom: []

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -233,7 +233,8 @@ testing:
 ccdb:
   encryption:
     rotation:
-      # Key labels must be < 256 characters long.
+      # Key labels must be <= 240 characters long. Each label will be prepended with the
+      # "ccdb_key_label_" value.
       key_labels:
       - encryption_key_0
       current_key_label: encryption_key_0

--- a/doc/secret_rotation.md
+++ b/doc/secret_rotation.md
@@ -32,7 +32,7 @@ ccdb:
       current_key_label: encryption_key_1
 ```
 
-**IMPORTANT** - key labels should be less than 256 characters long.
+**IMPORTANT** - key labels should be less than 240 characters long.
 
 Then, update the kubecf Helm installation. After Helm finishes its updates, trigger the
 `rotate-cc-database-key` errand:

--- a/doc/secret_rotation.md
+++ b/doc/secret_rotation.md
@@ -1,0 +1,49 @@
+# Secret rotation
+
+## CCDB encryption key
+
+**IMPORTANT** - Always backup the database before rotating the encryption key.
+
+The key used to encrypt the database is generated the first time kubecf is deployed. It is based on
+the Helm values:
+
+```yaml
+ccdb:
+  encryption:
+    rotation:
+      key_labels:
+      - encryption_key_0
+      current_key_label: encryption_key_0
+```
+
+For each label under `key_labels`, kubecf will generate an encryption key. The `current_key_label`
+indicates which key is currently being used.
+
+In order to rotate the CCDB encryption key, add a new label to `key_labels` (keeping the old
+labels), and mark the `current_key_label` with the newly added label. Example:
+
+```yaml
+ccdb:
+  encryption:
+    rotation:
+      key_labels:
+      - encryption_key_0
+      - encryption_key_1
+      current_key_label: encryption_key_1
+```
+
+**IMPORTANT** - key labels should be less than 256 characters long.
+
+Then, update the kubecf Helm installation. After Helm finishes its updates, trigger the
+`rotate-cc-database-key` errand:
+
+**Note** - the following command assumes the Helm installation is named `kubecf` and it was
+installed to the `kubecf` namespace. These values may be different depending on how kubecf was
+installed.
+
+```sh
+kubectl patch qjob kubecf-rotate-cc-database-key \
+  --namespace kubecf \
+  --type merge \
+  --patch '{"spec":{"trigger":{"strategy":"now"}}}'
+```


### PR DESCRIPTION
## Description

Adds the `rotate-cc-database-key` errand with a mechanism for rotating the CCDB encryption key.

Resolves https://github.com/SUSE/kubecf/issues/203.

## Motivation and Context

CF allows rotating the CCDB encryption key. This PR introduces a mechanism for doing it with kubecf using Helm.

## How Has This Been Tested?

1. Deployed kubecf with:
```yaml
ccdb:
  encryption:
    rotation:
      # Key labels must be < 256 characters long.
      key_labels:
      - encryption_key_0
      current_key_label: encryption_key_0
```
2. Ran smoke-tests.
3. Updated kubecf with:
```yaml
ccdb:
  encryption:
    rotation:
      # Key labels must be < 256 characters long.
      key_labels:
      - encryption_key_0
      - encryption_key_1
      current_key_label: encryption_key_1
```
4. Checked the new encryption key was correctly generated and interpolated in the new desired manifest created by cf-operator.
5. Ran the `rotate-cc-database-key` errand as instructed in the documentation introduced in this very same PR.
6. Checked the output of the errand saying that the old values encrypted with the previous encryption key where updated.
7. Ran smoke-tests again.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code has security implications.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
