### PR TITLE
Fixed gorouter http target port

### DIFF
--- a/deploy/helm/kubecf/assets/operations/instance_groups/router.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/router.yaml
@@ -5,7 +5,7 @@
     ports:
     - name: router
       protocol: TCP
-      internal: 8000
+      internal: 80
     - name: router-ssl
       protocol: TCP
       internal: 443

--- a/deploy/helm/kubecf/templates/ingress.yaml
+++ b/deploy/helm/kubecf/templates/ingress.yaml
@@ -122,7 +122,7 @@ spec:
   - name: http
     protocol: TCP
     port: 80
-    targetPort: 8000
+    targetPort: 80
   - name: https
     protocol: TCP
     port: 443


### PR DESCRIPTION
## Description

Gorouter listens on port 80, instead of 8000 for its HTTP traffic.

## Motivation and Context

The HTTP traffic on gorouter was not working.

## How Has This Been Tested?

Deployed kubecf, pushed an app and accessed it over the HTTP protocol on port 80.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
