### PR TITLE
Exposed the healthcheck port for tcp-router

### DIFF
--- a/deploy/helm/kubecf/templates/ingress.yaml
+++ b/deploy/helm/kubecf/templates/ingress.yaml
@@ -193,6 +193,10 @@ spec:
     app.kubernetes.io/instance: {{ $root.Release.Name | quote }}
     app.kubernetes.io/version: {{ default $root.Chart.Version $root.Chart.AppVersion | quote }}
   ports:
+  - name: healthcheck
+    protocol: TCP
+    port: 80
+    targetPort: 80
   {{- range $port := until (int (add 1 (sub $service.port_range.end $service.port_range.start))) }}
   {{- $port = add $port $service.port_range.start }}
   - name: "tcp-route-{{ $port }}"


### PR DESCRIPTION
## Description

Since `tcp-router` will only listen on the TCP port range when it's required, it provides healthcheck on port 80 (default) for upstream load balancers to probe.

## Motivation and Context

Upstream load balancers like the classic AWS ELB require the healthcheck to pass in order to mark the instances as `In Service`.

## How Has This Been Tested?

Deployed kubecf on EKS and verified that the classic ELB marks the instances as `In Service`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
