### PR TITLE
Added annotations option for services

### DIFF
--- a/deploy/helm/kubecf/templates/ingress.yaml
+++ b/deploy/helm/kubecf/templates/ingress.yaml
@@ -106,6 +106,10 @@ kind: Service
 metadata:
   name: "{{ $root.Release.Name }}-router-public"
   namespace: {{ $root.Release.Namespace | quote }}
+  {{- if $service.annotations }}
+  annotations:
+    {{- toYaml $service.annotations | nindent 4 }}
+  {{- end }}
   labels:
     app.kubernetes.io/component: router
     app.kubernetes.io/instance: {{ $root.Release.Name | quote }}
@@ -145,6 +149,10 @@ kind: Service
 metadata:
   name: "{{ $root.Release.Name }}-ssh-proxy-public"
   namespace: {{ $root.Release.Namespace | quote }}
+  {{- if $service.annotations }}
+  annotations:
+    {{- toYaml $service.annotations | nindent 4 }}
+  {{- end }}
   labels:
     app.kubernetes.io/component: ssh-proxy
     app.kubernetes.io/instance: {{ $root.Release.Name | quote }}
@@ -180,6 +188,10 @@ kind: Service
 metadata:
   name: "{{ $root.Release.Name }}-tcp-router-public"
   namespace: {{ $root.Release.Namespace | quote }}
+  {{- if $service.annotations }}
+  annotations:
+    {{- toYaml $service.annotations | nindent 4 }}
+  {{- end }}
   labels:
     app.kubernetes.io/component: tcp-router
     app.kubernetes.io/instance: {{ $root.Release.Name | quote }}

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -134,14 +134,17 @@ sizing:
 # features.ingress.enabled is false.
 services:
   router:
+    annotations: ~
     type: LoadBalancer
     externalIPs: []
     clusterIP: ~
   ssh-proxy:
+    annotations: ~
     type: LoadBalancer
     externalIPs: []
     clusterIP: ~
   tcp-router:
+    annotations: ~
     type: LoadBalancer
     externalIPs: []
     clusterIP: ~


### PR DESCRIPTION
## Description

Operators deploying kubecf can pass arbitrary annotations for each individual service. It's particularly useful to pass cloud provider-specific annotations.
http://web.archive.org/web/20200104141554/https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#aws

## How Has This Been Tested?

Deployed kubecf on EKS with the following annotation:

```yaml
services:
  router:
    annotations:
      service.beta.kubernetes.io/aws-load-balancer-type: nlb
  ssh-proxy:
    annotations:
      service.beta.kubernetes.io/aws-load-balancer-type: nlb
  tcp-router:
    annotations:
      service.beta.kubernetes.io/aws-load-balancer-type: nlb
```

Asserted that the LBs created were of the type Network Load Balancer (NLB).

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
