### PR TITLE
Add PSP and default bindings

### DIFF
--- a/deploy/helm/kubecf/templates/rbac.yaml
+++ b/deploy/helm/kubecf/templates/rbac.yaml
@@ -49,7 +49,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Release.Name }}-default
+  name: {{ .Release.Name }}-default-psp
   namespace: {{ .Release.Namespace | quote }}
 rules:
 - apiGroups: [policy]
@@ -64,13 +64,13 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Release.Name }}-default
+  name: {{ .Release.Name }}-default-psp
   namespace: {{ .Release.Namespace | quote }}
   annotations:
     rbac.authorization.kubernetes.io/autoupdate: "true"
 roleRef:
   kind: Role
-  name: {{ .Release.Name }}-default
+  name: {{ .Release.Name }}-default-psp
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount

--- a/deploy/helm/kubecf/templates/rbac.yaml
+++ b/deploy/helm/kubecf/templates/rbac.yaml
@@ -1,0 +1,78 @@
+{{- if not .Values.kube.psp.default }}
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+  name: {{ .Release.Name }}-default
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - NET_BIND_SERVICE
+  - SYS_ADMIN
+  - SYS_RESOURCE
+  defaultAllowPrivilegeEscalation: true
+  fsGroup:
+    rule: RunAsAny
+  hostPorts:
+  - max: 65535
+    min: 0
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - configMap
+  - secret
+  - emptyDir
+  - downwardAPI
+  - projected
+  - persistentVolumeClaim
+  - nfs
+  - rbd
+  - cephFS
+  - glusterfs
+  - fc
+  - iscsi
+  - cinder
+  - gcePersistentDisk
+  - awsElasticBlockStore
+  - azureDisk
+  - azureFile
+  - vsphereVolume
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-default
+  namespace: {{ .Release.Namespace | quote }}
+rules:
+- apiGroups: [policy]
+  {{- if .Values.kube.psp.default }}
+  resourceNames: [{{ .Values.kube.psp.default | quote }}]
+  {{- else }}
+  resourceNames: [{{ .Release.Name }}-default]
+  {{- end }}
+  resources: [podsecuritypolicies]
+  verbs: [use]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-default
+  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+roleRef:
+  kind: Role
+  name: {{ .Release.Name }}-default
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: {{ .Release.Namespace | quote }}

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -43,6 +43,11 @@ kube:
   #   | awk 'match($0, /cluster-cidr=(.*)/, range) { print range[1] }'
   # There is no default value for `--cluster-cidr`.
   pod_cluster_ip_range: ~
+  # The psp key contains the configuration related to Pod Security Policies. By default, a PSP will
+  # be generated with the necessary permissions for running KubeCF. To pass an existing PSP and
+  # prevent KubeCF from creating a new one, set the kube.psp.default with the PSP name.
+  psp:
+    default: ~
 
 releases:
   # The defaults for all releases, where we do not otherwise override them.


### PR DESCRIPTION
## Description

Fixes https://github.com/SUSE/kubecf/issues/306.

By default, KubeCF will create a PSP for its enjoyment, while allowing an existing PSP to be passed via the `kube.psp.default` Helm value. The PSP is then bound to the default service account in the namespace kubecf is installed.

## Motivation and Context

Please, visit https://github.com/SUSE/kubecf/issues/306 for more context.

## How Has This Been Tested?

Deployed on CaaSP 4, which is very restrictive on PSPs.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
