### PR TITLE
Use Weave CNI plugin with Kind

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -82,6 +82,12 @@ http_file(
     urls = [project.kube_dashboard.url],
 )
 
+http_file(
+    name = "weave_container_network_plugin",
+    sha256 = project.weave_container_network_plugin.sha256,
+    urls = [project.weave_container_network_plugin.url],
+)
+
 http_archive(
     name = "bazel_skylib",
     sha256 = project.skylib.sha256,

--- a/def.bzl
+++ b/def.bzl
@@ -105,6 +105,10 @@ project = struct(
         url = "https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.0-beta1/aio/deploy/recommended.yaml",
         sha256 = "f849252870818a2971dfc3c4f8a8c5f58a57606bc2b5f221d7ab693e1d1190e0",
     ),
+    weave_container_network_plugin = struct(
+        url = "https://github.com/weaveworks/weave/releases/download/latest_release/weave-daemonset-k8s-1.11.yaml",
+        sha256 = "3f6d84c16f46dd57a362446dfa8e313d9e401b0cabafef10da280c634a00ac0f",
+    ),
     skylib = struct(
         version = "0.9.0",
         sha256 = "1dde365491125a3db70731e25658dfdd3bc5dbdfd11b840b3e987ecf043c7ca0",

--- a/def.bzl
+++ b/def.bzl
@@ -106,7 +106,7 @@ project = struct(
         sha256 = "f849252870818a2971dfc3c4f8a8c5f58a57606bc2b5f221d7ab693e1d1190e0",
     ),
     weave_container_network_plugin = struct(
-        url = "https://github.com/weaveworks/weave/releases/download/latest_release/weave-daemonset-k8s-1.11.yaml",
+        url = "https://github.com/weaveworks/weave/releases/download/v2.6.0/weave-daemonset-k8s-1.11.yaml",
         sha256 = "3f6d84c16f46dd57a362446dfa8e313d9e401b0cabafef10da280c634a00ac0f",
     ),
     skylib = struct(

--- a/dev/kind/config.yaml
+++ b/dev/kind/config.yaml
@@ -1,0 +1,4 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  disableDefaultCNI: true

--- a/dev/kind/def.bzl
+++ b/dev/kind/def.bzl
@@ -18,19 +18,23 @@ def _kind_impl(ctx):
         export KIND="{kind}"
         export CLUSTER_NAME="{cluster_name}"
         export KUBECTL="{kubectl}"
+        export KIND_CONFIG="{kind_config}"
         export METRICS_SERVER="{metrics_server}"
         export K8S_VERSION="${{K8S_VERSION:-{k8s_version}}}"
         export LOCAL_PATH_STORAGE_YAML="{local_path_storage_yaml}"
         export KUBE_DASHBOARD_YAML="{kube_dashboard}"
+        export WEAVE_CONTAINER_NETWORK_PLUGIN="{weave_container_network_plugin}"
         "{script}"
     """.format(
         kind = ctx.executable._kind.short_path,
         cluster_name = ctx.attr.cluster_name,
         kubectl = ctx.executable._kubectl.short_path,
+        kind_config = ctx.file._kind_config.short_path,
         metrics_server = metrics_server_dir,
         k8s_version = ctx.attr.k8s_version,
         local_path_storage_yaml = ctx.file._local_path_storage_yaml.short_path,
         kube_dashboard = ctx.file._kube_dashboard.short_path,
+        weave_container_network_plugin = ctx.file._weave_container_network_plugin.short_path,
         script = ctx.executable._script.path,
     )
     ctx.actions.write(executable, contents, is_executable = True)
@@ -38,8 +42,10 @@ def _kind_impl(ctx):
         ctx.executable._kind,
         ctx.executable._kubectl,
         ctx.executable._script,
+        ctx.file._kind_config,
         ctx.file._local_path_storage_yaml,
         ctx.file._kube_dashboard,
+        ctx.file._weave_container_network_plugin,
     ] + ctx.files._metrics_server
     return [DefaultInfo(
         executable = executable,
@@ -65,6 +71,10 @@ attrs = {
         default = "@kubectl//:binary",
         executable = True,
     ),
+    "_kind_config": attr.label(
+        default = "//dev/kind:config.yaml",
+        allow_single_file = True,
+    ),
     "_metrics_server": attr.label(
         default = "@com_github_kubernetes_incubator_metrics_server//:deploy",
         allow_files = True,
@@ -75,6 +85,10 @@ attrs = {
     ),
     "_kube_dashboard": attr.label(
         default = "@kube_dashboard//file",
+        allow_single_file = True,
+    ),
+    "_weave_container_network_plugin": attr.label(
+        default = "@weave_container_network_plugin//file",
         allow_single_file = True,
     ),
 }


### PR DESCRIPTION
## Description

It enables the use of network policies, especially to block ingress and egress in order to run internetless test suites.

## Motivation and Context

The default CNI plugin used by Kind doesn't allow network policies.

## How Has This Been Tested?

1. From a pod in the default namespace, it succeeded to ping 8.8.8.8.
2. Applied a network policy to block all Ingress and Egress in the default namespace:
```
kubectl apply -f - <<'EOF'                                                                                                               tassis@thulio-laptop
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: block-all
  namespace: default
spec:
  podSelector: {}
  policyTypes:
  - Ingress
  - Egress
EOF
```
3. From the same pod as step 1, it failed to ping 8.8.8.8.
4. After removing the network policy, it succeeded to ping 8.8.8.8 again.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
