### PR TITLE
[jsc#cap-1029] Publish bundles to newly established bucket.

### DIFF
--- a/.gitlab/pipelines/stages/publish.sh
+++ b/.gitlab/pipelines/stages/publish.sh
@@ -3,5 +3,9 @@
 set -o errexit -o nounset
 
 mc config host add "s3" "https://s3.amazonaws.com" "${AWS_ACCESS_KEY}" "${AWS_SECRET_KEY}"
+
 mc cp output/kubecf-*.tgz "s3/scf-v3"
 echo "URL: https://scf-v3.s3.amazonaws.com/$(basename output/kubecf-*.tgz)"
+
+mc cp output/bundle-*.tgz "s3/kubecf"
+echo "URL: https://kubecf.s3.amazonaws.com/$(basename output/bundle-*.tgz)"


### PR DESCRIPTION
## Description

Extended the gitlab `publish.sh` script with code to upload the bundle tar archive to a newly made bucket for it and similar transient artifacts.

## Motivation and Context

See https://jira.suse.com/browse/CAP-1029
This is also a follow up to PR #218.

## How Has This Been Tested?

In the gitlab pipeline, see

  - https://gitlab.com/susecf/kubecf/pipelines/111546611/builds
  - https://gitlab.com/susecf/kubecf/-/jobs/412105734

Note, the tarball uploaded by this test has already been removed from the bucket.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
