### PR TITLE
fix: Eirini's loggregator extension in WARN level

### DIFF
--- a/deploy/helm/kubecf/assets/operations/instance_groups/eirini.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/eirini.yaml
@@ -122,9 +122,8 @@
       properties:
         quarks:
           envs:
-          # TODO: this isn't working for some reason - the env var is not present in the pod.
           - name: EIRINI_LOGGREGATOR_BRIDGE_LOGLEVEL
-            value: debug
+            value: WARN
         eirini-loggregator-bridge:
           loggregator_ca: '((loggregator_ca.certificate))'
           loggregator_cert: '((loggregator_tls_agent.certificate))'


### PR DESCRIPTION
## Description

The log level for the `eirini-loggregator-bridge` extension should be WARN by default, not DEBUG.

## Motivation and Context

The `DEBUG` level is too verbose for production environments (obviously).

## How Has This Been Tested?

Checked that the debugging statements are gone.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
