### PR TITLE
fix: log-cache memory consumption spike

### DIFF
--- a/deploy/helm/kubecf/templates/sizing.yaml
+++ b/deploy/helm/kubecf/templates/sizing.yaml
@@ -151,15 +151,11 @@ data:
 {{- end }}
 {{- end }}
 
-{{- if .Values.sizing.doppler.instances }}
-    - type: replace
-      path: /instance_groups/name=doppler/instances
-      value: {{.Values.sizing.doppler.instances}}
-{{- else if not .Values.high_availability }}
+    # Temporarily fixes https://github.com/SUSE/kubecf/issues/241.
+    # TODO: properly investigate and fix log-cache.
     - type: replace
       path: /instance_groups/name=doppler/instances
       value: 1
-{{- end }}
 
 {{- if .Values.sizing.log_api.instances }}
     - type: replace

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -121,8 +121,6 @@ sizing:
     instances: ~
   diego_cell:
     instances: ~
-  doppler:
-    instances: ~
   eirini:
     instances: ~
   log_api:


### PR DESCRIPTION
## Description

The log-cache goes wild with memory consumption when it has more than 1 replica. This is a temporary fix.

## Motivation and Context

Please, see https://github.com/SUSE/kubecf/issues/241.

## How Has This Been Tested?

Deployed in HA mode and made sure doppler only got 1 instance. Then ran smoke-tests (which has proven to cause this bug).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
