### PR TITLE
Fix Eirini extensions default namespace

### DIFF
--- a/deploy/helm/kubecf/assets/operations/instance_groups/eirini.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/eirini.yaml
@@ -87,7 +87,7 @@
           operator_webhook_host: "0.0.0.0"
           operator_webhook_port: 8443
           operator_webhook_servicename: {{ .Release.Name }}-eirini-persi
-          operator_webhook_namespace: {{ .Release.Name }}
+          operator_webhook_namespace: {{ .Release.Namespace }}
     - name: eirini-ssh-proxy
       release: eirini
       properties:
@@ -116,7 +116,7 @@
           operator_webhook_host: "0.0.0.0"
           operator_webhook_port: 2999
           operator_webhook_servicename: {{ .Release.Name }}-eirini-ssh
-          operator_webhook_namespace: {{ .Release.Name }}
+          operator_webhook_namespace: {{ .Release.Namespace }}
     - name: eirini-loggregator-bridge
       release: eirini
       properties:


### PR DESCRIPTION
Otherwise it assumes the scf deployment is named afterward the release,
not allowing to deploy in different namespaces.

## Motivation and Context
Deploying KubeCF+eirini in a different namespace rather than default would fail with:

```
kube-system kube-controller-manager-kubecf-eirini-master-control-plane kube-controller-manager I0127 10:34:59.061436       1 event.go:221] Event(v1.ObjectReference{Kind:"Job", Namespace:"susecf-scf-eirini", Name:"c2449eae-e00f-4e50-8d99-476a919b5ec4", UID:"af7fd9ed-40ec-11ea-99a3-0242b5c338b0", APIVersion:"batch/v1", ResourceVersion:"8472", FieldPath:""}): type: 'Warning' reason: 'FailedCreate' Error creating: Internal error occurred: failed calling webhook "0.eirini-ssh.org": Post https://susecf-scf-eirini-ssh.susecf-scf.svc:443/0?timeout=30s: service "susecf-scf-eirini-ssh" not found
```
 

## How Has This Been Tested?
Locally with Kind

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
