### PR TITLE
Fixing out of memory issue when scaling doppler instances

### DIFF
--- a/deploy/helm/kubecf/assets/operations/instance_groups/doppler.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/doppler.yaml
@@ -3,6 +3,10 @@
   path: /variables/name=log_cache_ca/options/common_name
   value: log-cache-ca
 
+- type: replace
+  path: /instance_groups/name=doppler/jobs/name=log-cache/properties/memory_limit_percent?
+  value: 25
+
 # Add quarks properties for doppler.
 - type: replace
   path: /instance_groups/name=doppler/jobs/name=doppler/properties/quarks?

--- a/deploy/helm/kubecf/templates/sizing.yaml
+++ b/deploy/helm/kubecf/templates/sizing.yaml
@@ -151,11 +151,15 @@ data:
 {{- end }}
 {{- end }}
 
-    # Temporarily fixes https://github.com/SUSE/kubecf/issues/241.
-    # TODO: properly investigate and fix log-cache.
+{{- if .Values.sizing.doppler.instances }}
+    - type: replace
+      path: /instance_groups/name=doppler/instances
+      value: {{.Values.sizing.doppler.instances}}
+{{- else if not .Values.high_availability }}
     - type: replace
       path: /instance_groups/name=doppler/instances
       value: 1
+{{- end }}
 
 {{- if .Values.sizing.log_api.instances }}
     - type: replace

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -191,6 +191,8 @@ sizing:
     instances: ~
   diego_cell:
     instances: ~
+  doppler:
+    instances: ~
   eirini:
     instances: ~
   log_api:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
fixes: https://github.com/SUSE/kubecf/issues/241

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`log-cache` by default is configured to 50% of total memory available to the instance:

https://github.com/cloudfoundry/log-cache-release/blob/v2.6.4/jobs/log-cache/spec#L35-L37

which exceeds the amount of memory actually available to be used:

```
/:/var/vcap/jobs/log-cache# cat /proc/meminfo   
MemTotal:       15652300 kB
MemFree:          569484 kB
MemAvailable:    9008472 kB
```

Therefore, this fix will limit the memory to 25% which falls under the actual available memory.
 
Discussion on CF Slack: https://cloudfoundry.slack.com/archives/CBFB7NP9B/p1580161281014400

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->
Locally on minikube by scaling the doppler instances to two and running smoke-tests.
```
❯ k logs kubecf-smoke-tests-ca77bb96d4d42c8c-znzvg -n kubecf -c smoke-tests-smoke-tests -f
kubectl logs kubecf-smoke-tests-ca77bb96d4d42c8c-znzvg -n kubecf -c smoke-tests-smoke-tests -f
Running smoke tests...
Running binaries smoke/isolation_segments/isolation_segments.test
smoke/logging/logging.test
smoke/runtime/runtime.test
[1580245198] CF-Isolation-Segment-Smoke-Tests - 4 specs - 4 nodes SSSS SUCCESS! 13.545755112s 
[1580245198] CF-Logging-Smoke-Tests - 2 specs - 4 nodes S• SUCCESS! 1m3.746576247s 
[1580245198] CF-Runtime-Smoke-Tests - 2 specs - 4 nodes S• SUCCESS! 1m4.298290082s 

Ginkgo ran 3 suites in 2m21.645606928s
Test Suite Passed

```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
