### PR TITLE
Documentation explaining the process for general secret rotation

### DIFF
--- a/doc/Contribute.md
+++ b/doc/Contribute.md
@@ -270,14 +270,14 @@ applied before attempting to apply it for real.
 ## Rotating Secrets
 
 __Rotating secrets__ is in general the process of updating one or more
-secrets to new values and restarting all affecteds pods so that they
+secrets to new values and restarting all affected pods so that they
 will use these new values.
 
 Most of the process is automatic. How to trigger it is explained
 in [General Secret Rotation](secret_rotation_general.md).
 
-Beyond this the keys used to encrypt the Cloud Controller Database
-(CCDB) can also be rotated, however they do not exist as general
+Beyond this, the keys used to encrypt the Cloud Controller Database
+(CCDB) can also be rotated, however, they do not exist as general
 secrets of the KubeCF deployment. This means that the general process
 explained above __does not apply__ to them.
 

--- a/doc/Contribute.md
+++ b/doc/Contribute.md
@@ -16,6 +16,7 @@ which go deeper into the details of each aspect.
   - [Linting](#linting)
   - [Patching](#patching)
   - [BOSH Development Workflow]
+  - [Rotating secrets](#rotating-secrets)
 
 ## Deployment
 
@@ -265,3 +266,20 @@ without changing the result.
 
 The existing patch scripts do this by checking if the patch is already
 applied before attempting to apply it for real.
+
+## Rotating Secrets
+
+__Rotating secrets__ is in general the process of updating one or more
+secrets to new values and restarting all affecteds pods so that they
+will use these new values.
+
+Most of the process is automatic. How to trigger it is explained
+in [General Secret Rotation](secret_rotation_general.md).
+
+Beyond this the keys used to encrypt the Cloud Controller Database
+(CCDB) can also be rotated, however they do not exist as general
+secrets of the KubeCF deployment. This means that the general process
+explained above __does not apply__ to them.
+
+Their custom process is explained in
+[Rotating the CCDB encryption keys](secret_rotation.md).

--- a/doc/secret_rotation_general.md
+++ b/doc/secret_rotation_general.md
@@ -1,0 +1,96 @@
+# Secret Rotation
+
+Note, this document explains general rotation of secrets.
+
+The instructions to rotate the CCDB keys specifically are in
+[a separate document](secret_rotation.md).
+
+The audience of this document are
+
+  - Developers working on KubeCF.
+
+  - Operators deploying KubeCF.
+
+# Background
+
+One of the features KubeCF (or rather the CF operator it sits on top of)
+provides is the ability to declare secrets (passwords, certificates, ...)
+and have the system automatically generate something suitably random
+for such on deployment, and distribute the results to the pods using them.
+
+This removes the burden from human operators to come up with lots of
+such just to have all the internal components of KubeCF properly wired
+up for secure communication.
+
+However, even with this operators may wish to change such secrets from
+time to time, or on a schedule. In other words, re-randomize the
+board, and limit the lifetime of any particular secret.
+
+As a note on terminology, this kind of change is called
+__rotating a secret__.
+
+This document describes how this can be done, in the context of KubeCF.
+
+# Finding secrets
+
+Retrieve the list of all secrets maintained by a KubeCF deployment via
+
+    kubectl get quarkssecret -n kubecf
+
+To see the information about a specific secret, for example the NATS password, use
+
+    kubectl get quarkssecret -n kubecf kubecf.var-nats-password -o yaml
+
+Note that each quarkssecret has a corresponding regulare k8s secret it
+controls.
+
+    kubectl get secret -n kubecf
+    kubectl get secret -n kubecf kubecf.var-nats-password -o yaml
+
+# Requesting a rotation for a specific secret
+
+We keep using `kubecf.var-nats-password` as our example secret.
+
+To rotate this secret:
+
+  1. Create yaml file for a ConfigMap of the form:
+
+         ---				   
+         apiVersion: v1			   
+         kind: ConfigMap			   
+         metadata:			   
+           name: rotate-kubecf.var-nats-password
+           labels:			   
+             quarks.cloudfoundry.org/secret-rotation: "true"
+         data:				   
+           secrets: '["kubecf.var-nats-password"]'
+
+     Note, while the name of this ConfigMap can be technically
+     anything (allowed by k8s syntax) I personally prefer to use a
+     name derived from the name of the secret itself, to make the
+     connection clear.
+
+     Note further that while this example rotates only a single secret
+     the `data.secrets` key accepts an array of secret names, allowing
+     the simultaneous rotation of many secrets together.
+
+  2. Apply this ConfigMap using
+
+         kubectl apply -f /path/to/your/yaml/file
+
+  3. The CF operator will see that this ConfigMap is for it to
+     process, because of the special label
+
+         quarks.cloudfoundry.org/secret-rotation: "true"
+
+     and knows that it has to invoke a rotation of the referenced
+     secrets.
+
+     The actions of the operator can be followed in its log.
+
+   4. After the operator has done the rotation, i.e. has not only
+      changed the secrets, but also restarted all affected pods (the
+      users of the rotated secrets), delete the trigger config map
+      again:
+      
+         kubectl delete -f /path/to/your/yaml/file

--- a/doc/secret_rotation_general.md
+++ b/doc/secret_rotation_general.md
@@ -76,7 +76,7 @@ To rotate this secret:
 
   2. Apply this ConfigMap using
 
-         kubectl apply -f /path/to/your/yaml/file
+         kubectl apply -n kubecf -f /path/to/your/yaml/file
 
   3. The CF operator will see that this ConfigMap is for it to
      process, because of the special label
@@ -93,4 +93,4 @@ To rotate this secret:
       users of the rotated secrets), delete the trigger config map
       again:
       
-         kubectl delete -f /path/to/your/yaml/file
+         kubectl delete -n kubecf -f /path/to/your/yaml/file

--- a/doc/secret_rotation_general.md
+++ b/doc/secret_rotation_general.md
@@ -1,11 +1,11 @@
 # Secret Rotation
 
-Note, this document explains general rotation of secrets.
+Note, this document explains the general rotation of secrets.
 
 The instructions to rotate the CCDB keys specifically are in
 [a separate document](secret_rotation.md).
 
-The audience of this document are
+The audience of this document are:
 
   - Developers working on KubeCF.
 
@@ -13,17 +13,18 @@ The audience of this document are
 
 # Background
 
-One of the features KubeCF (or rather the CF operator it sits on top of)
-provides is the ability to declare secrets (passwords, certificates, ...)
-and have the system automatically generate something suitably random
-for such on deployment, and distribute the results to the pods using them.
+One of the features KubeCF (or rather the cf-operator it sits on top
+of) provides is the ability to declare secrets (passwords and
+certificates) and have the system automatically generate something
+suitably random for such on deployment, and distribute the results to
+the pods using them.
 
 This removes the burden from human operators to come up with lots of
 such just to have all the internal components of KubeCF properly wired
 up for secure communication.
 
-However, even with this operators may wish to change such secrets from
-time to time, or on a schedule. In other words, re-randomize the
+However, even with this, operators may wish to change such secrets
+from time to time, or on a schedule. In other words, re-randomize the
 board, and limit the lifetime of any particular secret.
 
 As a note on terminology, this kind of change is called
@@ -35,17 +36,17 @@ This document describes how this can be done, in the context of KubeCF.
 
 Retrieve the list of all secrets maintained by a KubeCF deployment via
 
-    kubectl get quarkssecret -n kubecf
+    kubectl get quarkssecret --namespace kubecf
 
 To see the information about a specific secret, for example the NATS password, use
 
-    kubectl get quarkssecret -n kubecf kubecf.var-nats-password -o yaml
+    kubectl get quarkssecret --namespace kubecf kubecf.var-nats-password --output yaml
 
 Note that each quarkssecret has a corresponding regulare k8s secret it
 controls.
 
-    kubectl get secret -n kubecf
-    kubectl get secret -n kubecf kubecf.var-nats-password -o yaml
+    kubectl get secret --namespace kubecf
+    kubectl get secret --namespace kubecf kubecf.var-nats-password --output yaml
 
 # Requesting a rotation for a specific secret
 
@@ -53,7 +54,7 @@ We keep using `kubecf.var-nats-password` as our example secret.
 
 To rotate this secret:
 
-  1. Create yaml file for a ConfigMap of the form:
+  1. Create a YAML file for a ConfigMap of the form:
 
          ---				   
          apiVersion: v1			   
@@ -66,31 +67,30 @@ To rotate this secret:
            secrets: '["kubecf.var-nats-password"]'
 
      Note, while the name of this ConfigMap can be technically
-     anything (allowed by k8s syntax) I personally prefer to use a
-     name derived from the name of the secret itself, to make the
+     anything (allowed by k8s syntax) we recommend using a name
+     derived from the name of the secret itself, to make the
      connection clear.
 
-     Note further that while this example rotates only a single secret
-     the `data.secrets` key accepts an array of secret names, allowing
-     the simultaneous rotation of many secrets together.
+     Note further that while this example rotates only a single
+     secret, the `data.secrets` key accepts an array of secret names,
+     allowing the simultaneous rotation of many secrets together.
 
-  2. Apply this ConfigMap using
+  2. Apply this ConfigMap using:
 
-         kubectl apply -n kubecf -f /path/to/your/yaml/file
+         kubectl apply --namespace kubecf -f /path/to/your/yaml/file
 
-  3. The CF operator will see that this ConfigMap is for it to
-     process, because of the special label
+  3. The cf-operator will process this ConfigMap due the label
 
          quarks.cloudfoundry.org/secret-rotation: "true"
 
      and knows that it has to invoke a rotation of the referenced
      secrets.
 
-     The actions of the operator can be followed in its log.
+     The actions of the cf-operator can be followed in its log.
 
-   4. After the operator has done the rotation, i.e. has not only
+   4. After the cf-operator has done the rotation, i.e. has not only
       changed the secrets, but also restarted all affected pods (the
       users of the rotated secrets), delete the trigger config map
       again:
       
-         kubectl delete -n kubecf -f /path/to/your/yaml/file
+         kubectl delete --namespace kubecf -f /path/to/your/yaml/file


### PR DESCRIPTION
New file explaining the process. Further linked pre-existing file for the custom process required by CCDB keys into the new toplevel section.

## Description

Added a new section to `doc/Contribute.md`. Added new file containing the bulk of the explanations.

## Motivation and Context

See #44 

## How Has This Been Tested?

Manual testing in a minikube environment.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

While the new documentation was added in the developer doc section of the project operators deploying KubeCF are also a proper audience for this information. As such the main product documentation should be extend to contain the same information.


