### PR TITLE
Bump catapult version in post_publish pipeline

### DIFF
--- a/.concourse/post_publish.yaml
+++ b/.concourse/post_publish.yaml
@@ -19,7 +19,7 @@ resources:
   source:
     uri: https://github.com/SUSE/catapult
   version:
-    ref: 18957254f9da0920fa1d0674932f87db07bf83ce
+    ref: 05b6a6ff325993a3f97f173b6c048af416a0274a
 - name: status.src
   type: github-status
   source:


### PR DESCRIPTION
Required after https://github.com/SUSE/kubecf/pull/356

## Description
Bumps the catapult version which handles the kubecf changes

## Motivation and Context
Pipeline fails in deploying steps

## How Has This Been Tested?
Public concourse pipelines.
Before: https://concourse.suse.dev/teams/main/pipelines/post-publish/jobs/deploy-diego/builds/12
After: https://concourse.suse.dev/teams/main/pipelines/post-publish/jobs/deploy-diego/builds/13
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
