### PR TITLE
Fix metadata generation for version interpolation

### DIFF
--- a/deploy/helm/kubecf/BUILD.bazel
+++ b/deploy/helm/kubecf/BUILD.bazel
@@ -13,7 +13,7 @@ load("//:def.bzl", "project")
 metadata_file_generator(
     name = "metadata",
     file = "Metadata.yaml",
-    operator_chart = project.external_files["cf_operator"].urls[0]
+    operator_chart = project.external_files["cf_operator"].urls[0].format( version = project.external_files["cf_operator"].version )
 )
 
 filegroup(


### PR DESCRIPTION
Signed-off-by: Dimitris Karakasilis <DKarakasilis@suse.com>


## Description
Fixing the version interpolation (https://concourse.suse.dev/teams/main/pipelines/post-publish/jobs/deploy-eirini/builds/19)

Otherwise deployment fails with, as url aren't interpolated with the version:
```
Error: failed to download "https://cf-operators.s3.amazonaws.com/release/helm-charts/cf-operator-{version}.tgz" (hint: running `helm repo update` may help)
Error: validation failed: unable to recognize "": no matches for kind "BOSHDeployment" in version "quarks.cloudfoundry.org/v1alpha1"
```