### PR TITLE
Feature: Debug support. Print helm commands generated by bazel rules.

### DIFF
--- a/rules/helm/delete.tmpl.rb
+++ b/rules/helm/delete.tmpl.rb
@@ -9,4 +9,6 @@ namespace = '[[namespace]]'
 
 args = [helm, 'delete', install_name, '--namespace', namespace]
 
+puts "CMD #{args}"
+
 exit Process.wait2(Process.spawn(*args)).last.exitstatus

--- a/rules/helm/upgrade.tmpl.rb
+++ b/rules/helm/upgrade.tmpl.rb
@@ -33,4 +33,6 @@ set_values = set_values.map do |key, value|
 end
 args.concat(*set_values)
 
+puts "CMD #{args}"
+
 exit Process.wait2(Process.spawn(*args)).last.exitstatus


### PR DESCRIPTION

## Description

Modified the `rules/helm/{delete,upgrade}.tmpl.rb` files to print the generated command (line) just before it is executed.

## Motivation and Context

It should help directly debugging issues with bazel-generated helm commands, and indirectly when comparing a local setup against other environments and the helm command used therein.

## How Has This Been Tested?

Bazel goals making use of the helm rules (Ex `bazel run //dev/cf_operator:apply`) were invoked manually, and confirmed that the generated command is seen in the terminal:

```
...
Target //dev/cf_operator:apply up-to-date:
  bazel-bin/dev/cf_operator/apply.rb
INFO: Elapsed time: 0.272s, Critical Path: 0.12s
INFO: 0 processes.
INFO: Build completed successfully, 2 total actions
INFO: Build completed successfully, 2 total actions
CMD ["../helm/helm", "upgrade", "cf-operator", "../cf_operator/file/downloaded", "--namespace", "cf-operator", "--install", "--reuse-values", "--set", "global.operator.watchNamespace=kubecf"]
Release "cf-operator" has been upgraded. Happy Helming!
...
```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
