### PR TITLE
Add SITs instance group

### DIFF
--- a/deploy/helm/kubecf/assets/operations/instance_groups/sync-integration-tests.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/sync-integration-tests.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.testing.sync_integration_tests.enabled -}}
+
+- path: /instance_groups/-
+  type: replace
+  value:
+    instances: 1
+    jobs:
+    - name: sync-integration-tests
+      properties:
+        quarks:
+        bpm:
+          processes: []
+        sync_integration_tests:
+          bbs:
+            svc:
+              name: diego-api-bbs
+              namespace: {{ .Release.Namespace }}
+              port: 8889
+          config:
+            bbs_client_cert_contents: ((diego_bbs_client.certificate))
+            bbs_client_key_contents: ((diego_bbs_client.private_key))
+            cf_admin_password: ((cf_admin_password))
+            cf_api: api.((system_domain))
+            cf_apps_domain: ((system_domain))
+          setup:
+            flake_attempts: 3
+            nodes: 4
+            verbose: false
+      release: sync-integration-tests
+    lifecycle: errand
+    name: sync-integration-tests
+    networks:
+    - name: default
+    stemcell: default
+    update:
+      serial: true
+    vm_type: minimal
+
+{{- end }}

--- a/deploy/helm/kubecf/assets/operations/instance_groups/sync-integration-tests.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/sync-integration-tests.yaml
@@ -3,6 +3,13 @@
 - path: /instance_groups/-
   type: replace
   value:
+    azs:
+    - z1
+    env:
+      bosh:
+        agent:
+          settings:
+            serviceAccountName: {{ .Release.Name }}-tests-sits
     instances: 1
     jobs:
     - name: sync-integration-tests
@@ -13,15 +20,17 @@
         sync_integration_tests:
           bbs:
             svc:
-              name: diego-api-bbs
+              name: {{ .Release.Namespace }}-diego-api
               namespace: {{ .Release.Namespace }}
               port: 8889
           config:
             bbs_client_cert_contents: ((diego_bbs_client.certificate))
             bbs_client_key_contents: ((diego_bbs_client.private_key))
+            cf_admin_user: admin
             cf_admin_password: ((cf_admin_password))
             cf_api: api.((system_domain))
             cf_apps_domain: ((system_domain))
+            cf_skip_ssl_validation: true
           setup:
             flake_attempts: 3
             nodes: 4

--- a/deploy/helm/kubecf/assets/operations/releases.yaml
+++ b/deploy/helm/kubecf/assets/operations/releases.yaml
@@ -63,6 +63,14 @@
     name: brain-tests
 {{- end }}
 
+{{- if .Values.testing.sync_integration_tests.enabled }}
+{{- $releases = append $releases "sync-integration-tests" }}
+- path: /releases/-
+  type: replace
+  value:
+    name: sync-integration-tests
+{{- end }}
+
 # Add app-autoscaler related releases.
 {{- if .Values.features.autoscaler.enabled }}
 {{- $releases = append $releases "app-autoscaler" }}

--- a/deploy/helm/kubecf/templates/sync-integration-tests.yaml
+++ b/deploy/helm/kubecf/templates/sync-integration-tests.yaml
@@ -1,0 +1,224 @@
+{{- if .Values.testing.sync_integration_tests.enabled -}}
+
+# Service account, roles, and cluster role for the sync integration tests.
+# Raw kube objects going into the chart.
+
+# Service account "tests-sits" is used by the instance group "sync-integration-tests"
+---
+apiVersion: "v1"
+kind: "ServiceAccount"
+metadata:
+  name: "{{ .Release.Name }}-tests-sits"
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/component: "{{ .Release.Name }}-tests-sits"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "kubecf.fullname" . }}
+    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "kubecf.chart" . }}
+
+# Role "test-role-sits" only used by account "tests-sits"
+---
+apiVersion: "rbac.authorization.k8s.io/v1"
+kind: "Role"
+metadata:
+  name: "{{ .Release.Name }}-test-role-sits"
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/component: "{{ .Release.Name }}-test-role-sits"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "kubecf.fullname" . }}
+    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "kubecf.chart" . }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - "services"
+  verbs:
+  - "create"
+  - "get"
+  - "delete"
+  - "list"
+  - "patch"
+- apiGroups:
+  - "extensions"
+  resourceNames:
+  - "default"
+  resources:
+  - "podsecuritypolicies"
+  verbs:
+  - "use"
+- apiGroups:
+  - "extensions"
+  resources:
+  - "replicasets"
+  verbs:
+  - "create"
+  - "get"
+  - "list"
+  - "delete"
+  - "update"
+- apiGroups:
+  - "apps"
+  resources:
+  - "statefulsets"
+  verbs:
+  - "create"
+  - "get"
+  - "update"
+  - "delete"
+  - "list"
+  - "patch"
+- apiGroups:
+  - ""
+  resources:
+  - "pods"
+  verbs:
+  - "create"
+  - "get"
+  - "list"
+  - "delete"
+  - "update"
+  - "patch"
+- apiGroups:
+  - ""
+  resources:
+  - "pods/exec"
+  verbs:
+  - "create"
+  - "delete"
+- apiGroups:
+  - ""
+  resources:
+  - "pods/log"
+  verbs:
+  - "create"
+  - "delete"
+  - "get"
+  - "list"
+- apiGroups:
+  - ""
+  resources:
+  - "secrets"
+  verbs:
+  - "create"
+  - "get"
+  - "delete"
+  - "list"
+
+# Role binding for service account "tests-sits" and role "test-role-sits"
+---
+apiVersion: "rbac.authorization.k8s.io/v1"
+kind: "RoleBinding"
+metadata:
+  name: "{{ .Release.Name }}-tests-sits-test-role-sits-binding"
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/component: "{{ .Release.Name }}-tests-sits-test-role-sits-binding"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "kubecf.fullname" . }}
+    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "kubecf.chart" . }}
+subjects:
+- kind: "ServiceAccount"
+  name: "{{ .Release.Name }}-tests-sits"
+  namespace: {{ .Release.Namespace | quote }}
+roleRef:
+  apiGroup: "rbac.authorization.k8s.io"
+  kind: "Role"
+  name: "{{ .Release.Name }}-test-role-sits"
+
+# Cluster role "test-cluster-role" only used by account "tests-sits"
+---
+apiVersion: "rbac.authorization.k8s.io/v1"
+kind: "ClusterRole"
+metadata:
+  name: "{{ .Release.Namespace }}-{{ .Release.Name }}-test-cluster-role"
+  labels:
+    app.kubernetes.io/component: "{{ .Release.Namespace }}-{{ .Release.Name }}-test-cluster-role"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "kubecf.fullname" . }}
+    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "kubecf.chart" . }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - "namespaces"
+  verbs:
+  - "create"
+  - "get"
+  - "delete"
+- apiGroups:
+  - ""
+  resources:
+  - "pods"
+  - "pods/log"
+  - "namespaces"
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
+- apiGroups:
+  - ""
+  resources:
+  - "pods/portforward"
+  verbs:
+  - "create"
+- apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - "clusterrolebindings"
+  verbs:
+  - "delete"
+- apiGroups:
+  - ""
+  resources:
+  - "persistentvolumes"
+  - "persistentvolumeclaims"
+  verbs:
+  - "get"
+  - "list"
+- apiGroups:
+  - "storage.k8s.io"
+  resources:
+  - "storageclasses"
+  verbs:
+  - "get"
+  - "list"
+- apiGroups:
+  - "batch"
+  resources:
+  - "jobs"
+  verbs:
+  - "get"
+  - "list"
+
+# Cluster role binding for service account "tests-sits" and cluster role "test-cluster-role"
+---
+apiVersion: "rbac.authorization.k8s.io/v1"
+kind: "ClusterRoleBinding"
+metadata:
+  name: "{{ .Release.Namespace }}-{{ .Release.Name }}-tests-sits-test-cluster-role-cluster-binding"
+  labels:
+    app.kubernetes.io/component: "{{ .Release.Namespace }}-{{ .Release.Name }}-tests-sits-test-cluster-role-cluster-binding"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "kubecf.fullname" . }}
+    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "kubecf.chart" . }}
+subjects:
+- kind: "ServiceAccount"
+  name: "{{ .Release.Name }}-tests-sits"
+  namespace: {{ .Release.Namespace | quote }}
+roleRef:
+  kind: "ClusterRole"
+  apiGroup: "rbac.authorization.k8s.io"
+  name: "{{ .Release.Namespace }}-{{ .Release.Name }}-test-cluster-role"
+
+{{- end }}

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -84,7 +84,7 @@ releases:
   sle15:
     version: "10.93"
   sync-integration-tests:
-    version: v0.0.2
+    version: v0.0.3
   suse-staticfile-buildpack:
     url: registry.suse.com/cap-staging
     version: "1.5.2.1"

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -83,6 +83,8 @@ releases:
     version: "39"
   sle15:
     version: "10.93"
+  sync-integration-tests:
+    version: v0.0.2
   suse-staticfile-buildpack:
     url: registry.suse.com/cap-staging
     version: "1.5.2.1"
@@ -292,6 +294,8 @@ testing:
     enabled: false
   smoke_tests:
     enabled: true
+  sync_integration_tests:
+    enabled: false
 
 ccdb:
   encryption:

--- a/doc/tests.md
+++ b/doc/tests.md
@@ -1,12 +1,13 @@
 # Testing
 
-The smoke, brain, and acceptance tests can be run after Kubecf
+The smoke, brain, acceptance, and sync integration tests can be run after Kubecf
 deployment has completed, via:
 
 ```sh
 bazel run //testing/smoke_tests
 bazel run //testing/brain_tests
 bazel run //testing/acceptance_tests
+bazel run //testing/sync_integration_tests
 ```
 
 The [acceptance tests] can be limited to specific suites of interest,

--- a/doc/tests_sits.md
+++ b/doc/tests_sits.md
@@ -1,0 +1,8 @@
+# Sync Integration tests
+
+The bazel target __//testing/sync_integration_tests__ starts a run of the
+[SUSE Sync Integration Tests].
+
+[SUSE Sync Integration Tests]: https://github.com/SUSE/sync-integration-tests-release
+
+See also the [entire set of available tests](tests.md).

--- a/testing/sync_integration_tests/BUILD.bazel
+++ b/testing/sync_integration_tests/BUILD.bazel
@@ -1,0 +1,13 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//rules/kubectl:def.bzl", kubectl_patch = "patch")
+load("//:def.bzl", "project")
+
+kubectl_patch(
+    name = "sync_integration_tests",
+    namespace = project.namespace,
+    resource_type = "qjob",
+    resource_name = "kubecf-sync-integration-tests",
+    patch_type = "merge",
+    patch_file = ":trigger.yaml",
+)

--- a/testing/sync_integration_tests/trigger.yaml
+++ b/testing/sync_integration_tests/trigger.yaml
@@ -1,0 +1,3 @@
+spec:
+  trigger:
+    strategy: now


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR intends to add `sync-integration-tests` instance group and other required components in order to run the tests.

fixes: https://github.com/SUSE/kubecf/issues/120
changes in SITs release: https://github.com/SUSE/sync-integration-tests-release/pull/1

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[SITs](https://github.com/cloudfoundry/sync-integration-tests) form an important part of CF test suites as they focus on testing the sync functionality between Cloud Controller and Diego.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->
This has been tested locally on `minikube`. Please find attached the [logs](https://github.com/SUSE/kubecf/files/4238423/sits.log) from local test execution. There are future plans to add the SITs in pipeline pos-publish concourse pipeline.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
